### PR TITLE
feat: add topic filter dropdown in course schedule and detail page

### DIFF
--- a/src/schedule-and-details/details-section/DetailsSection.scss
+++ b/src/schedule-and-details/details-section/DetailsSection.scss
@@ -4,3 +4,10 @@
     height: 20rem;
   }
 }
+
+.dropdown-topic {
+  .dropdown-menu {
+    overflow: auto;
+    height: 20rem;
+  }
+}

--- a/src/schedule-and-details/details-section/SearchableCreatableDropdown.jsx
+++ b/src/schedule-and-details/details-section/SearchableCreatableDropdown.jsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import { Form, Dropdown } from '@openedx/paragon';
+
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+const SearchableCreatableDropdown = ({ 
+    options, 
+    value, 
+    onChange, 
+    placeholder,
+    onCreateTopic 
+  }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [searchTerm, setSearchTerm] = useState('');
+    const [isCreating, setIsCreating] = useState(false);
+  
+    const filteredOptions = options.filter(option =>
+      option.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+  
+    const showCreateOption = searchTerm.trim() && 
+      !options.some(opt => opt.toLowerCase() === searchTerm.trim().toLowerCase());
+  
+    const handleCreateTopic = async () => {
+      if (!searchTerm.trim()) return;
+      
+      setIsCreating(true);
+      try {
+        const { data } = await getAuthenticatedHttpClient().post(
+          `${getConfig().STUDIO_BASE_URL}/wikimedia_general/api/v0/topics`,
+          { name: searchTerm.trim() }
+        );
+        
+        // First update the selection
+        onChange(data.name);
+        // Then notify parent about the new topic
+        await onCreateTopic(data.name);
+        // Clear search and close dropdown
+        setSearchTerm('');
+        setIsOpen(false);
+  
+      } catch (error) {
+        console.error('Error creating topic:', error);
+        alert('Network error: Could not create topic');
+      } finally {
+        setIsCreating(false);
+      }
+    };
+  
+    return (
+      <div className="searchable-creatable-dropdown">
+        <Dropdown show={isOpen} onToggle={setIsOpen} className="bg-white">
+          <Dropdown.Toggle variant="outline-primary" id="topicDropdown">
+            {value || placeholder}
+          </Dropdown.Toggle>
+          <Dropdown.Menu>
+            <div className="px-3 py-2">
+              <Form.Control
+                type="text"
+                placeholder="Search or create topic..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                onClick={(e) => e.stopPropagation()}
+              />
+            </div>
+            <Dropdown.Divider />
+            <div style={{ maxHeight: '200px', overflowY: 'auto' }}>
+              {filteredOptions.length > 0 ? (
+                filteredOptions.map((option) => (
+                  <Dropdown.Item
+                    key={option}
+                    onClick={() => {
+                      onChange(option);
+                      setSearchTerm('');
+                      setIsOpen(false);
+                    }}
+                  >
+                    {option}
+                  </Dropdown.Item>
+                ))
+              ) : (
+                !showCreateOption && (
+                  <Dropdown.Item disabled>No topics found</Dropdown.Item>
+                )
+              )}
+              {showCreateOption && (
+                <>
+                  <Dropdown.Divider />
+                  <Dropdown.Item
+                    onClick={handleCreateTopic}
+                    disabled={isCreating}
+                    className="text-primary font-weight-bold"
+                  >
+                    {isCreating ? 'Creating...' : `+ Create "${searchTerm}"`}
+                  </Dropdown.Item>
+                </>
+              )}
+            </div>
+          </Dropdown.Menu>
+        </Dropdown>
+      </div>
+    );
+  };
+  // ========== END: CUSTOM TOPIC DROPDOWN ENHANCEMENT ==========
+  
+  export default SearchableCreatableDropdown;

--- a/src/schedule-and-details/details-section/index.jsx
+++ b/src/schedule-and-details/details-section/index.jsx
@@ -7,12 +7,17 @@ import SectionSubHeader from '../../generic/section-sub-header';
 import messages from './messages';
 
 const DetailsSection = ({
-  language, languageOptions, onChange,
+  language, languageOptions, topic, topicOptions, onChange,
 }) => {
   const intl = useIntl();
   const formattedLanguage = () => {
     const result = languageOptions.find((arr) => arr[0] === language);
     return result ? result[1] : intl.formatMessage(messages.dropdownEmpty);
+  };
+
+  const formattedTopic = () => {
+    const result = topicOptions.find((t) => t === topic);
+    return result ? result : intl.formatMessage(messages.topicDropdownEmpty);
   };
 
   return (
@@ -42,17 +47,44 @@ const DetailsSection = ({
           {intl.formatMessage(messages.dropdownHelpText)}
         </Form.Control.Feedback>
       </Form.Group>
+
+      <Form.Group className="form-group-custom dropdown-topic">
+        <Form.Label>{intl.formatMessage(messages.topicDropdownLabel)}</Form.Label>
+        <Dropdown className="bg-white">
+          <Dropdown.Toggle variant="outline-primary" id="topicDropdown">
+            {formattedTopic()}
+          </Dropdown.Toggle>
+          <Dropdown.Menu>
+            {topicOptions.map((option) => (
+              <Dropdown.Item
+                key={option}
+                onClick={() => onChange(option, 'topic')}
+              >
+                {option}
+              </Dropdown.Item>
+            ))}
+          </Dropdown.Menu>
+        </Dropdown>
+        <Form.Control.Feedback>
+          {intl.formatMessage(messages.topicDropdownHelpText)}
+        </Form.Control.Feedback>
+      </Form.Group>
     </section>
   );
 };
 
 DetailsSection.defaultProps = {
   language: '',
+  topic: '',
 };
 
 DetailsSection.propTypes = {
   language: PropTypes.string,
   languageOptions: PropTypes.arrayOf(
+    PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+  ).isRequired,
+  topic: PropTypes.string,
+  topicOptions: PropTypes.arrayOf(
     PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   ).isRequired,
   onChange: PropTypes.func.isRequired,

--- a/src/schedule-and-details/details-section/index.jsx
+++ b/src/schedule-and-details/details-section/index.jsx
@@ -1,24 +1,49 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Form, Dropdown } from '@openedx/paragon';
 
 import SectionSubHeader from '../../generic/section-sub-header';
 import messages from './messages';
+import SearchableCreatableDropdown from './SearchableCreatableDropdown';
+
 
 const DetailsSection = ({
   language, languageOptions, topic, topicOptions, onChange,
 }) => {
   const intl = useIntl();
+  
   const formattedLanguage = () => {
     const result = languageOptions.find((arr) => arr[0] === language);
     return result ? result[1] : intl.formatMessage(messages.dropdownEmpty);
   };
+  
+  
+  // ========== CUSTOM ==========
+  const [localTopicOptions, setLocalTopicOptions] = useState(topicOptions);
+  
+  // Update local options when props change
+  useEffect(() => {
+    setLocalTopicOptions(topicOptions);
+  }, [topicOptions]);
 
   const formattedTopic = () => {
-    const result = topicOptions.find((t) => t === topic);
-    return result ? result : intl.formatMessage(messages.topicDropdownEmpty);
+    const result = localTopicOptions.find((t) => t === topic);
+    return result || topic || intl.formatMessage(messages.topicDropdownEmpty);
   };
+  
+  const handleTopicCreation = async (newTopic) => {
+    // Add new topic to local options immediately
+    setLocalTopicOptions(prev => {
+      if (!prev.includes(newTopic)) {
+        return [...prev, newTopic];
+      }
+      return prev;
+    });
+    // Optionally trigger parent component refresh
+    console.log('New topic created:', newTopic);
+  };
+  // ========== END ==========
 
   return (
     <section className="section-container details-section">
@@ -48,27 +73,21 @@ const DetailsSection = ({
         </Form.Control.Feedback>
       </Form.Group>
 
+      {/* ========== START: MODIFIED TOPIC DROPDOWN ========== */}
       <Form.Group className="form-group-custom dropdown-topic">
         <Form.Label>{intl.formatMessage(messages.topicDropdownLabel)}</Form.Label>
-        <Dropdown className="bg-white">
-          <Dropdown.Toggle variant="outline-primary" id="topicDropdown">
-            {formattedTopic()}
-          </Dropdown.Toggle>
-          <Dropdown.Menu>
-            {topicOptions.map((option) => (
-              <Dropdown.Item
-                key={option}
-                onClick={() => onChange(option, 'topic')}
-              >
-                {option}
-              </Dropdown.Item>
-            ))}
-          </Dropdown.Menu>
-        </Dropdown>
+        <SearchableCreatableDropdown
+          options={localTopicOptions}
+          value={formattedTopic()}
+          onChange={(newTopic) => onChange(newTopic, 'topic')}
+          placeholder={intl.formatMessage(messages.topicDropdownEmpty)}
+          onCreateTopic={handleTopicCreation}
+        />
         <Form.Control.Feedback>
           {intl.formatMessage(messages.topicDropdownHelpText)}
         </Form.Control.Feedback>
       </Form.Group>
+      {/* ========== END: MODIFIED TOPIC DROPDOWN ========== */}
     </section>
   );
 };
@@ -85,7 +104,7 @@ DetailsSection.propTypes = {
   ).isRequired,
   topic: PropTypes.string,
   topicOptions: PropTypes.arrayOf(
-    PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+    PropTypes.string.isRequired,
   ).isRequired,
   onChange: PropTypes.func.isRequired,
 };

--- a/src/schedule-and-details/details-section/messages.js
+++ b/src/schedule-and-details/details-section/messages.js
@@ -21,6 +21,18 @@ const messages = defineMessages({
     id: 'course-authoring.schedule-section.details.dropdown.empty',
     defaultMessage: 'Select language',
   },
+  topicDropdownLabel: {
+    id: 'authoring.details.topic.label',
+    defaultMessage: 'Course Topic',
+  },
+  topicDropdownEmpty: {
+    id: 'authoring.details.topic.empty',
+    defaultMessage: 'Select a topic',
+  },
+  topicDropdownHelpText: {
+    id: 'authoring.details.topic.help',
+    defaultMessage: 'Choose the primary topic for this course',
+  },
 });
 
 export default messages;

--- a/src/schedule-and-details/index.jsx
+++ b/src/schedule-and-details/index.jsx
@@ -60,6 +60,7 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
     isCreditCourse,
     upgradeDeadline,
     languageOptions,
+    topicOptions,
     marketingEnabled,
     licensingEnabled,
     aboutPageEditable,
@@ -115,6 +116,7 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
     endDate,
     license,
     language,
+    topic,
     subtitle,
     overview,
     duration,
@@ -271,6 +273,8 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
                     <DetailsSection
                       language={language}
                       languageOptions={languageOptions}
+                      topic={topic}
+                      topicOptions={topicOptions}
                       onChange={handleValuesChange}
                     />
                   )}


### PR DESCRIPTION
## Add Topic Filter Dropdown to Course Schedule and Details Page

### Summary
This PR adds a new "Topic" dropdown to the Course Schedule and Details page, allowing course authors to select a topic category for their course from a list of available options.

### Changes

#### UI Components
- **DetailsSection Component**: Added topic dropdown alongside the existing language dropdown
  - New `topic` and `topicOptions` props
  - `formattedTopic()` helper function to display selected topic or placeholder
  - Dropdown renders all available topics from the backend
  - New `SearchableCreatableDropdown` component

#### Styling
- **DetailsSection.scss**: Added `.dropdown-topic` styles with scrollable menu (max height: 20rem) to match language dropdown behavior

#### Data Flow
- **index.jsx**: 
  - Added `topicOptions` from settings API response
  - Added `topic` to course details state
  - Passed both props to `DetailsSection` component
  - Topic selection handled via existing `handleValuesChange` callback


---

**Related PRs**:
edx-platform: https://github.com/wikimedia/edx-platform/pull/581
openedx-wikilearn-features: https://github.com/wikimedia/openedx-wikilearn-features/pull/17

**Ticket**: https://github.com/wikimedia/edx-platform/issues/569