### PR TITLE
fix: added styling to ensure language widget doesnt overflow

### DIFF
--- a/env.config.js
+++ b/env.config.js
@@ -147,6 +147,14 @@ const TranslationCheckbox = ({ subsection, section, unit }) => {
   );
 };
 
+
+const languageSelectStyle = {
+    position: 'absolute',
+    top: '100%',
+    right: '0',
+    marginTop: '8px',
+};
+
 const LanguageWidget = ({ intl }) => {
   const [options, setOptions] = useState([]);
   const [showWidget, setShowWidget] = useState(false);
@@ -224,6 +232,7 @@ const LanguageWidget = ({ intl }) => {
     <select
       id="language-select"
       className="select-dropdown mx-2"
+      style={languageSelectStyle}
       onChange={handleChange}
       value={intl.locale}
       aria-label="Select language"


### PR DESCRIPTION
Issue: https://github.com/wikimedia/edx-platform/issues/603

In the Studio, the main menu gets disorganized when the window is resized.

### Now: 
<img width="1434" height="179" alt="Screenshot 2026-02-27 at 1 39 28 PM" src="https://github.com/user-attachments/assets/a76dd960-747b-4fc8-bb91-0a40c878a409" />

### Before:
<img width="1600" height="481" alt="image" src="https://github.com/user-attachments/assets/36b600d7-de4f-4672-a07f-44b4d92d7777" />
