### PR TITLE
fix: refresh search token after library 

### DIFF
--- a/src/library-authoring/create-library/data/apiHooks.test.tsx
+++ b/src/library-authoring/create-library/data/apiHooks.test.tsx
@@ -63,6 +63,9 @@ describe('create library apiHooks', () => {
       expect(invalidateQueriesSpy).toHaveBeenCalledWith({
         queryKey: libraryAuthoringQueryKeys.contentLibraryList(),
       });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: ['content_search'],
+      });
     });
   });
 

--- a/src/library-authoring/create-library/data/apiHooks.ts
+++ b/src/library-authoring/create-library/data/apiHooks.ts
@@ -23,6 +23,8 @@ export const useCreateLibraryV2 = () => {
     mutationFn: createLibraryV2,
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.contentLibraryList() });
+      // Invalidate the search token to refresh with the new library's access_id
+      queryClient.invalidateQueries({ queryKey: ['content_search'] });
     },
   });
 };


### PR DESCRIPTION
## Description
This PR cherry-picks upstream [(#2924)](https://github.com/openedx/frontend-app-authoring/pull/2924)


## Ticket
https://projects.arbisoft.com/project/edly-product/task/8307