### PR TITLE
feat: unify approve and publish into single action

### DIFF
--- a/src/course-lifecycle/components/CourseLifecycleSection.test.tsx
+++ b/src/course-lifecycle/components/CourseLifecycleSection.test.tsx
@@ -8,14 +8,12 @@ const mockUseCourseAggregateState = jest.fn();
 const mockSubmitCourseMutate = jest.fn();
 const mockApproveCourseMutate = jest.fn();
 const mockRequestCourseChangesMutate = jest.fn();
-const mockPublishCourseMutate = jest.fn();
 
 jest.mock('@src/course-lifecycle/data/apiHooks', () => ({
   useCourseAggregateState: (...args: any[]) => mockUseCourseAggregateState(...args),
   useSubmitCourseForReview: () => ({ mutate: mockSubmitCourseMutate, isPending: false }),
   useApproveCourse: () => ({ mutate: mockApproveCourseMutate, isPending: false }),
   useRequestCourseChanges: () => ({ mutate: mockRequestCourseChangesMutate, isPending: false }),
-  usePublishCourse: () => ({ mutate: mockPublishCourseMutate, isPending: false }),
   // useCourseComments + useAddCourseReply needed by CourseCommentsPanel child
   useCourseComments: () => ({ data: [], isLoading: false }),
   useAddCourseReply: () => ({ mutate: jest.fn(), isPending: false }),
@@ -115,14 +113,14 @@ describe('<CourseLifecycleSection />', () => {
     expect(screen.getByRole('button', { name: 'Submit All for Review' })).toBeInTheDocument();
   });
 
-  it('renders "Approve All" button when canApprove=true', () => {
+  it('renders "Approve & Publish All" button when canApprove=true', () => {
     mockUseCourseAggregateState.mockReturnValue({
       data: mockCourseAggregateState({ canSubmit: false, canApprove: true }),
       isLoading: false,
       error: null,
     });
     render(<CourseLifecycleSection courseId={courseId} />);
-    expect(screen.getByRole('button', { name: 'Approve All' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Approve & Publish All' })).toBeInTheDocument();
   });
 
   it('renders "Request Changes" button when canRequestChanges=true', () => {
@@ -166,16 +164,6 @@ describe('<CourseLifecycleSection />', () => {
     );
   });
 
-  it('renders "Publish Course" button when canPublish=true', () => {
-    mockUseCourseAggregateState.mockReturnValue({
-      data: mockCourseAggregateState({ canSubmit: false, canPublish: true }),
-      isLoading: false,
-      error: null,
-    });
-    render(<CourseLifecycleSection courseId={courseId} />);
-    expect(screen.getByRole('button', { name: 'Publish Course' })).toBeInTheDocument();
-  });
-
   it('does not render action buttons when no action is allowed', () => {
     mockUseCourseAggregateState.mockReturnValue({
       data: mockCourseAggregateState({
@@ -186,8 +174,7 @@ describe('<CourseLifecycleSection />', () => {
     });
     render(<CourseLifecycleSection courseId={courseId} />);
     expect(screen.queryByRole('button', { name: 'Submit All for Review' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Approve All' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Publish Course' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Approve & Publish All' })).not.toBeInTheDocument();
   });
 
   it('calls submitMutation.mutate() when Submit All for Review is clicked', () => {
@@ -201,26 +188,15 @@ describe('<CourseLifecycleSection />', () => {
     expect(mockSubmitCourseMutate).toHaveBeenCalledTimes(1);
   });
 
-  it('calls approveMutation.mutate() when Approve All is clicked', () => {
+  it('calls approveMutation.mutate() when Approve & Publish All is clicked', () => {
     mockUseCourseAggregateState.mockReturnValue({
       data: mockCourseAggregateState({ canSubmit: false, canApprove: true }),
       isLoading: false,
       error: null,
     });
     render(<CourseLifecycleSection courseId={courseId} />);
-    fireEvent.click(screen.getByRole('button', { name: 'Approve All' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Approve & Publish All' }));
     expect(mockApproveCourseMutate).toHaveBeenCalledTimes(1);
-  });
-
-  it('calls publishMutation.mutate() when Publish Course is clicked', () => {
-    mockUseCourseAggregateState.mockReturnValue({
-      data: mockCourseAggregateState({ canSubmit: false, canPublish: true }),
-      isLoading: false,
-      error: null,
-    });
-    render(<CourseLifecycleSection courseId={courseId} />);
-    fireEvent.click(screen.getByRole('button', { name: 'Publish Course' }));
-    expect(mockPublishCourseMutate).toHaveBeenCalledTimes(1);
   });
 
   it('renders the CourseCommentsPanel when data is loaded', () => {

--- a/src/course-lifecycle/components/CourseLifecycleSection.tsx
+++ b/src/course-lifecycle/components/CourseLifecycleSection.tsx
@@ -9,7 +9,6 @@ import {
   useSubmitCourseForReview,
   useApproveCourse,
   useRequestCourseChanges,
-  usePublishCourse,
 } from '../data/apiHooks';
 import type { LifecycleState } from '../data/types';
 import { LifecycleBadge } from './LifecycleBadge';
@@ -40,7 +39,6 @@ export const CourseLifecycleSection = ({ courseId }: Props) => {
   const submitMutation = useSubmitCourseForReview(courseId);
   const approveMutation = useApproveCourse(courseId);
   const requestChangesMutation = useRequestCourseChanges(courseId);
-  const publishMutation = usePublishCourse(courseId);
 
   useRefreshOnPublish(data?.aggregateState, () => dispatch(fetchCourseOutlineIndexQuery(courseId)));
 
@@ -82,7 +80,7 @@ export const CourseLifecycleSection = ({ courseId }: Props) => {
             </>
           )}
 
-          {(data.canSubmit || data.canApprove || data.canRequestChanges || data.canPublish) && (
+          {(data.canSubmit || data.canApprove || data.canRequestChanges) && (
             <>
               <p className="x-small text-uppercase text-muted font-weight-bold mb-1 mt-3">Actions</p>
               <div className="d-flex flex-column gap-1">
@@ -105,7 +103,7 @@ export const CourseLifecycleSection = ({ courseId }: Props) => {
                     disabled={approveMutation.isPending}
                     onClick={() => approveMutation.mutate()}
                   >
-                    {approveMutation.isPending ? <Spinner animation="border" size="sm" /> : 'Approve All'}
+                    {approveMutation.isPending ? <Spinner animation="border" size="sm" /> : 'Approve & Publish All'}
                   </Button>
                 )}
                 {data.canRequestChanges && !showRequestForm && (
@@ -144,17 +142,6 @@ export const CourseLifecycleSection = ({ courseId }: Props) => {
                       </Button>
                     </div>
                   </div>
-                )}
-                {data.canPublish && (
-                  <Button
-                    variant="success"
-                    size="sm"
-                    className="w-100"
-                    disabled={publishMutation.isPending}
-                    onClick={() => publishMutation.mutate()}
-                  >
-                    {publishMutation.isPending ? <Spinner animation="border" size="sm" /> : 'Publish Course'}
-                  </Button>
                 )}
               </div>
             </>

--- a/src/course-lifecycle/components/LifecycleActionButtons.test.tsx
+++ b/src/course-lifecycle/components/LifecycleActionButtons.test.tsx
@@ -7,13 +7,11 @@ import { mockBlockReviewState } from '../data/api.mock';
 const mockSubmitMutate = jest.fn();
 const mockApproveMutate = jest.fn();
 const mockRequestChangesMutate = jest.fn();
-const mockPublishMutate = jest.fn();
 
 jest.mock('@src/course-lifecycle/data/apiHooks', () => ({
   useSubmitForReview: () => ({ mutate: mockSubmitMutate, isPending: false }),
   useApproveBlock: () => ({ mutate: mockApproveMutate, isPending: false }),
   useRequestChanges: () => ({ mutate: mockRequestChangesMutate, isPending: false }),
-  usePublishBlock: () => ({ mutate: mockPublishMutate, isPending: false }),
 }));
 
 const usageKey = 'block-v1:TestOrg+TestCourse+2025_T1+type@vertical+block@unit1';
@@ -25,37 +23,34 @@ describe('<LifecycleActionButtons />', () => {
 
   it('renders no buttons when all capability flags are false', () => {
     const blockState = mockBlockReviewState({
-      canSubmit: false, canApprove: false, canRequestChanges: false, canPublish: false,
+      canSubmit: false, canApprove: false, canRequestChanges: false,
     });
     render(<LifecycleActionButtons usageKey={usageKey} blockState={blockState} />);
     expect(screen.queryByRole('button', { name: 'Submit for Review' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Approve & Publish' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Request Changes' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Publish' })).not.toBeInTheDocument();
   });
 
-  it('renders no buttons when hasChanges=false and canPublish=false', () => {
+  it('renders no buttons when hasChanges=false', () => {
     const blockState = mockBlockReviewState({
-      canSubmit: true, canApprove: false, canRequestChanges: false, canPublish: false,
+      canSubmit: true, canApprove: false, canRequestChanges: false,
     });
     render(<LifecycleActionButtons usageKey={usageKey} blockState={blockState} hasChanges={false} />);
     expect(screen.queryByRole('button', { name: 'Submit for Review' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Publish' })).not.toBeInTheDocument();
   });
 
   it('renders "Submit for Review" button when canSubmit=true', () => {
     const blockState = mockBlockReviewState({ canSubmit: true });
     render(<LifecycleActionButtons usageKey={usageKey} blockState={blockState} />);
     expect(screen.getByRole('button', { name: 'Submit for Review' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Approve & Publish' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Request Changes' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Publish' })).not.toBeInTheDocument();
   });
 
-  it('renders "Approve" button when canApprove=true', () => {
+  it('renders "Approve & Publish" button when canApprove=true', () => {
     const blockState = mockBlockReviewState({ canSubmit: false, canApprove: true });
     render(<LifecycleActionButtons usageKey={usageKey} blockState={blockState} />);
-    expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Approve & Publish' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Submit for Review' })).not.toBeInTheDocument();
   });
 
@@ -65,19 +60,6 @@ describe('<LifecycleActionButtons />', () => {
     expect(screen.getByRole('button', { name: 'Request Changes' })).toBeInTheDocument();
   });
 
-  it('renders "Publish" button when canPublish=true', () => {
-    const blockState = mockBlockReviewState({ canSubmit: false, canPublish: true });
-    render(<LifecycleActionButtons usageKey={usageKey} blockState={blockState} />);
-    expect(screen.getByRole('button', { name: 'Publish' })).toBeInTheDocument();
-  });
-
-  it('hides workflow buttons but shows Publish when hasChanges=false and canPublish=true', () => {
-    const blockState = mockBlockReviewState({ canSubmit: true, canPublish: true });
-    render(<LifecycleActionButtons usageKey={usageKey} blockState={blockState} hasChanges={false} />);
-    expect(screen.queryByRole('button', { name: 'Submit for Review' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Publish' })).toBeInTheDocument();
-  });
-
   it('calls submitMutation.mutate() when Submit for Review button is clicked', () => {
     const blockState = mockBlockReviewState({ canSubmit: true });
     render(<LifecycleActionButtons usageKey={usageKey} blockState={blockState} />);
@@ -85,18 +67,11 @@ describe('<LifecycleActionButtons />', () => {
     expect(mockSubmitMutate).toHaveBeenCalledTimes(1);
   });
 
-  it('calls approveMutation.mutate() when Approve button is clicked', () => {
+  it('calls approveMutation.mutate() when Approve & Publish button is clicked', () => {
     const blockState = mockBlockReviewState({ canSubmit: false, canApprove: true });
     render(<LifecycleActionButtons usageKey={usageKey} blockState={blockState} />);
-    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Approve & Publish' }));
     expect(mockApproveMutate).toHaveBeenCalledTimes(1);
-  });
-
-  it('calls publishMutation.mutate() when Publish button is clicked', () => {
-    const blockState = mockBlockReviewState({ canSubmit: false, canPublish: true });
-    render(<LifecycleActionButtons usageKey={usageKey} blockState={blockState} />);
-    fireEvent.click(screen.getByRole('button', { name: 'Publish' }));
-    expect(mockPublishMutate).toHaveBeenCalledTimes(1);
   });
 
   it('clicking "Request Changes" shows the inline comment form', () => {

--- a/src/course-lifecycle/components/LifecycleActionButtons.tsx
+++ b/src/course-lifecycle/components/LifecycleActionButtons.tsx
@@ -3,7 +3,6 @@ import { Button, Form, Spinner } from '@openedx/paragon';
 import type { BlockReviewState } from '../data/types';
 import {
   useApproveBlock,
-  usePublishBlock,
   useRequestChanges,
   useSubmitForReview,
 } from '../data/apiHooks';
@@ -13,35 +12,30 @@ interface Props {
   usageKey: string;
   blockState: BlockReviewState;
   hasChanges?: boolean;
-  /** Called after a successful lifecycle publish — used by the unit page to refresh its Redux state. */
-  onPublishSuccess?: () => void;
 }
 
 export const LifecycleActionButtons = ({
-  usageKey, blockState, hasChanges, onPublishSuccess,
+  usageKey, blockState, hasChanges,
 }: Props) => {
   const submitMutation = useSubmitForReview(usageKey);
   const approveMutation = useApproveBlock(usageKey);
   const requestChangesMutation = useRequestChanges(usageKey);
-  const publishMutation = usePublishBlock(usageKey, { onSuccess: onPublishSuccess });
 
   const {
     showRequestForm, requestComment, setRequestComment, open, cancel, submit,
   } = useRequestChangesForm(requestChangesMutation);
 
   const {
-    canSubmit, canApprove, canRequestChanges, canPublish,
+    canSubmit, canApprove, canRequestChanges,
   } = blockState;
 
-  // When there are no pending changes, workflow buttons (submit/approve/request-changes)
-  // are irrelevant, but the Publish button must still show if the block is approved.
   const showWorkflowButtons = hasChanges !== false;
 
-  if (!showWorkflowButtons && !canPublish) {
+  if (!showWorkflowButtons) {
     return null;
   }
 
-  if (!canSubmit && !canApprove && !canRequestChanges && !canPublish) {
+  if (!canSubmit && !canApprove && !canRequestChanges) {
     return null;
   }
 
@@ -66,7 +60,7 @@ export const LifecycleActionButtons = ({
           disabled={approveMutation.isPending}
           onClick={() => approveMutation.mutate()}
         >
-          {approveMutation.isPending ? <Spinner animation="border" size="sm" /> : 'Approve'}
+          {approveMutation.isPending ? <Spinner animation="border" size="sm" /> : 'Approve & Publish'}
         </Button>
       )}
       {showWorkflowButtons && canRequestChanges && !showRequestForm && (
@@ -105,17 +99,6 @@ export const LifecycleActionButtons = ({
             </Button>
           </div>
         </div>
-      )}
-      {canPublish && (
-        <Button
-          variant="success"
-          size="sm"
-          className="w-100 my-1"
-          disabled={publishMutation.isPending}
-          onClick={() => publishMutation.mutate()}
-        >
-          {publishMutation.isPending ? <Spinner animation="border" size="sm" /> : 'Publish'}
-        </Button>
       )}
     </div>
   );

--- a/src/course-lifecycle/components/LifecycleModal.test.tsx
+++ b/src/course-lifecycle/components/LifecycleModal.test.tsx
@@ -10,8 +10,6 @@ const mockUseBlockState = jest.fn();
 const mockSubmitMutate = jest.fn();
 const mockApproveMutate = jest.fn();
 const mockRequestChangesMutate = jest.fn();
-const mockPublishMutate = jest.fn();
-
 // Mocks for BlockCommentsPanel child
 const mockUseBlockComments = jest.fn();
 const mockResolveMutate = jest.fn();
@@ -25,7 +23,6 @@ jest.mock('@src/course-lifecycle/data/apiHooks', () => ({
   useSubmitForReview: () => ({ mutate: mockSubmitMutate, isPending: false }),
   useApproveBlock: () => ({ mutate: mockApproveMutate, isPending: false }),
   useRequestChanges: () => ({ mutate: mockRequestChangesMutate, isPending: false }),
-  usePublishBlock: () => ({ mutate: mockPublishMutate, isPending: false }),
   useBlockComments: (...args: any[]) => mockUseBlockComments(...args),
   useResolveComment: () => ({ mutate: mockResolveMutate, isPending: false }),
   useDeleteComment: () => ({ mutate: mockDeleteMutate, isPending: false }),

--- a/src/course-lifecycle/components/LifecycleModal.tsx
+++ b/src/course-lifecycle/components/LifecycleModal.tsx
@@ -11,12 +11,10 @@ interface Props {
   blockId: string;
   displayName: string;
   hasChanges?: boolean;
-  /** Called after a successful lifecycle publish — used to refresh Redux outline state. */
-  onPublishSuccess?: () => void;
 }
 
 export const LifecycleModal = ({
-  isOpen, onClose, blockId, displayName, hasChanges, onPublishSuccess,
+  isOpen, onClose, blockId, displayName, hasChanges,
 }: Props) => {
   const { data: blockState, isLoading } = useBlockState(blockId);
 
@@ -49,7 +47,6 @@ export const LifecycleModal = ({
               usageKey={blockId}
               blockState={blockState}
               hasChanges={hasChanges}
-              onPublishSuccess={() => { onPublishSuccess?.(); onClose(); }}
             />
             <BlockCommentsPanel usageKey={blockId} />
           </>

--- a/src/course-lifecycle/components/LifecycleSection.tsx
+++ b/src/course-lifecycle/components/LifecycleSection.tsx
@@ -11,12 +11,10 @@ interface Props {
   usageKey: string;
   title?: string;
   hasChanges?: boolean;
-  /** Optional callback forwarded to LifecycleActionButtons — lets the host page react to a publish. */
-  onPublishSuccess?: () => void;
 }
 
 export const LifecycleSection = ({
-  usageKey, title = 'Review Status', hasChanges, onPublishSuccess,
+  usageKey, title = 'Review Status', hasChanges,
 }: Props) => {
   const queryClient = useQueryClient();
   const { data: blockState, isLoading, error } = useBlockState(usageKey);
@@ -52,7 +50,6 @@ export const LifecycleSection = ({
             usageKey={usageKey}
             blockState={blockState}
             hasChanges={hasChanges}
-            onPublishSuccess={onPublishSuccess}
           />
           <BlockCommentsPanel usageKey={usageKey} />
         </>

--- a/src/course-lifecycle/data/api.ts
+++ b/src/course-lifecycle/data/api.ts
@@ -37,7 +37,7 @@ export async function submitForReview(usageKey: string): Promise<BlockReviewStat
 
 export async function approveBlock(usageKey: string): Promise<BlockReviewState> {
   const { data } = await getAuthenticatedHttpClient().post(
-    `${getLifecycleBaseUrl()}/v1/blocks/${encodeURIComponent(usageKey)}/approve`,
+    `${getLifecycleBaseUrl()}/v1/blocks/${encodeURIComponent(usageKey)}/approve-and-publish`,
   );
   return camelCaseObject(data) as BlockReviewState;
 }
@@ -46,13 +46,6 @@ export async function requestChanges(usageKey: string, comments: string[]): Prom
   const { data } = await getAuthenticatedHttpClient().post(
     `${getLifecycleBaseUrl()}/v1/blocks/${encodeURIComponent(usageKey)}/request-changes`,
     { comments },
-  );
-  return camelCaseObject(data) as BlockReviewState;
-}
-
-export async function publishBlock(usageKey: string): Promise<BlockReviewState> {
-  const { data } = await getAuthenticatedHttpClient().post(
-    `${getLifecycleBaseUrl()}/v1/blocks/${encodeURIComponent(usageKey)}/publish`,
   );
   return camelCaseObject(data) as BlockReviewState;
 }
@@ -66,7 +59,7 @@ export async function submitCourseForReview(courseId: string): Promise<{ transit
 
 export async function approveCourse(courseId: string): Promise<{ transitioned: number }> {
   const { data } = await getAuthenticatedHttpClient().post(
-    `${getLifecycleBaseUrl()}/v1/courses/${encodeURIComponent(courseId)}/approve`,
+    `${getLifecycleBaseUrl()}/v1/courses/${encodeURIComponent(courseId)}/approve-and-publish`,
   );
   return data;
 }
@@ -75,13 +68,6 @@ export async function requestCourseChanges(courseId: string, comments: string[])
   const { data } = await getAuthenticatedHttpClient().post(
     `${getLifecycleBaseUrl()}/v1/courses/${encodeURIComponent(courseId)}/request-changes`,
     { comments },
-  );
-  return data;
-}
-
-export async function publishCourse(courseId: string): Promise<{ status: string }> {
-  const { data } = await getAuthenticatedHttpClient().post(
-    `${getLifecycleBaseUrl()}/v1/courses/${encodeURIComponent(courseId)}/publish`,
   );
   return data;
 }

--- a/src/course-lifecycle/data/apiHooks.ts
+++ b/src/course-lifecycle/data/apiHooks.ts
@@ -12,8 +12,6 @@ import {
   getBulkCourseAggregateStates,
   getCourseAggregateState,
   getCourseComments,
-  publishBlock,
-  publishCourse,
   requestChanges,
   requestCourseChanges,
   resolveComment,
@@ -62,6 +60,7 @@ export const useApproveCourse = (courseId: string) => {
     mutationFn: () => approveCourse(courseId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['lifecycle'] });
+      queryClient.invalidateQueries({ queryKey: courseOutlineQueryKeys.contentLibrary(courseId) });
     },
   });
 };
@@ -72,17 +71,6 @@ export const useRequestCourseChanges = (courseId: string) => {
     mutationFn: (comments: string[]) => requestCourseChanges(courseId, comments),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['lifecycle'] });
-    },
-  });
-};
-
-export const usePublishCourse = (courseId: string) => {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: () => publishCourse(courseId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['lifecycle'] });
-      queryClient.invalidateQueries({ queryKey: courseOutlineQueryKeys.contentLibrary(courseId) });
     },
   });
 };
@@ -125,6 +113,7 @@ export const useApproveBlock = (usageKey: string) => {
     mutationFn: () => approveBlock(usageKey),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['lifecycle'] });
+      queryClient.invalidateQueries({ queryKey: courseOutlineQueryKeys.contentLibrary(getCourseKey(usageKey)) });
     },
   });
 };
@@ -135,20 +124,6 @@ export const useRequestChanges = (usageKey: string) => {
     mutationFn: (comments: string[]) => requestChanges(usageKey, comments),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['lifecycle'] });
-    },
-  });
-};
-
-export const usePublishBlock = (usageKey: string, options?: { onSuccess?: () => void }) => {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: () => publishBlock(usageKey),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['lifecycle'] });
-      // Refresh all outline blocks for this course so status badges update without a page reload.
-      queryClient.invalidateQueries({ queryKey: courseOutlineQueryKeys.contentLibrary(getCourseKey(usageKey)) });
-      // Allows the unit page to re-fetch its Redux state after a lifecycle publish (see UnitInfoSidebar).
-      options?.onSuccess?.();
     },
   });
 };

--- a/src/course-lifecycle/index.ts
+++ b/src/course-lifecycle/index.ts
@@ -13,7 +13,6 @@ export {
   useSubmitCourseForReview,
   useApproveCourse,
   useRequestCourseChanges,
-  usePublishCourse,
   lifecycleQueryKeys,
 } from './data/apiHooks';
 export type {


### PR DESCRIPTION
 ## Summary

  - Removes `publishBlock` / `publishCourse` API functions and `usePublishBlock` / `usePublishCourse` hooks                                                        
  - Updates approve endpoint URLs from `.../approve` → `.../approve-and-publish`
  - Renames "Approve" → "Approve & Publish" (block modal) and "Approve All" → "Approve & Publish All" (course sidebar); removes standalone Publish buttons         
  - `useApproveBlock` / `useApproveCourse` onSuccess now invalidates outline query cache so the sidebar refreshes after publish          