### PR TITLE
feat: added the studio side frontend for program management

### DIFF
--- a/src/generic/create-or-rerun-course/CreateOrRerunCourseForm.jsx
+++ b/src/generic/create-or-rerun-course/CreateOrRerunCourseForm.jsx
@@ -29,6 +29,8 @@ const CreateOrRerunCourseForm = ({
   isCreateNewCourse,
   initialValues,
   onClickCancel,
+  onAfterCreate,
+  extraFields,
 }) => {
   const { courseId } = useParams();
   const savingStatus = useSelector(getSavingStatus);
@@ -50,7 +52,7 @@ const CreateOrRerunCourseForm = ({
     handleChange,
     hasErrorField,
     setFieldValue,
-  } = useCreateOrRerunCourse(initialValues);
+  } = useCreateOrRerunCourse(initialValues, onAfterCreate);
 
   const newCourseFields = [
     {
@@ -253,6 +255,7 @@ const CreateOrRerunCourseForm = ({
             )}
           </Form.Group>
         ))}
+        {extraFields}
         <ActionRow className="justify-content-start">
           <Button
             variant="outline-primary"
@@ -281,6 +284,8 @@ const CreateOrRerunCourseForm = ({
 CreateOrRerunCourseForm.defaultProps = {
   title: '',
   isCreateNewCourse: false,
+  onAfterCreate: undefined,
+  extraFields: null,
 };
 
 CreateOrRerunCourseForm.propTypes = {
@@ -293,6 +298,8 @@ CreateOrRerunCourseForm.propTypes = {
   }).isRequired,
   isCreateNewCourse: PropTypes.bool,
   onClickCancel: PropTypes.func.isRequired,
+  onAfterCreate: PropTypes.func,
+  extraFields: PropTypes.node,
 };
 
 export default CreateOrRerunCourseForm;

--- a/src/generic/create-or-rerun-course/hooks.jsx
+++ b/src/generic/create-or-rerun-course/hooks.jsx
@@ -18,7 +18,7 @@ import { updateSavingStatus, updatePostErrors } from '../data/slice';
 import { fetchOrganizationsQuery } from '../data/thunks';
 import messages from './messages';
 
-const useCreateOrRerunCourse = (initialValues) => {
+const useCreateOrRerunCourse = (initialValues, onAfterCreate = null) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -98,22 +98,32 @@ const useCreateOrRerunCourse = (initialValues) => {
 
   useEffect(() => {
     if (createOrRerunCourseSavingStatus === RequestStatus.SUCCESSFUL) {
-      dispatch(updateSavingStatus({ status: '' }));
-      const { url, destinationCourseKey } = redirectUrlObj;
-      // New courses' url to the outline page is provided in the url. However, for course
-      // re-runs the url is /course/. The actual destination for the rer-run's  outline
-      // is in the destionationCourseKey attribute from the api.
-      if (url) {
-        if (destinationCourseKey) {
-          navigate(`${url}${destinationCourseKey}`);
-        } else {
-          navigate(url);
+      (async () => {
+        dispatch(updateSavingStatus({ status: '' }));
+        const { url, destinationCourseKey } = redirectUrlObj;
+        // New courses: url is the full outline path e.g. /course/course-v1:Org+Num+Run,
+        // destinationCourseKey is absent. Reruns: url is /course/ and the key is in
+        // destinationCourseKey. Extract the key from url as a fallback so onAfterCreate
+        // is always called with a valid course key.
+        const courseKey = destinationCourseKey
+          ?? (url?.startsWith('/course/') ? url.slice('/course/'.length) || null : null);
+        if (onAfterCreate && courseKey) {
+          try {
+            await onAfterCreate(courseKey);
+          } catch { /* ignore — course was created, audience assignment is best-effort */ }
         }
-      }
+        if (url) {
+          if (destinationCourseKey) {
+            navigate(`${url}${destinationCourseKey}`);
+          } else {
+            navigate(url);
+          }
+        }
+      })();
     } else if (createOrRerunCourseSavingStatus === RequestStatus.FAILED) {
       dispatch(updateSavingStatus({ status: '' }));
     }
-  }, [createOrRerunCourseSavingStatus]);
+  }, [createOrRerunCourseSavingStatus, onAfterCreate]);
 
   const hasErrorField = (fieldName) => !!errors[fieldName] && !!touched[fieldName];
   const isFormInvalid = Object.keys(errors).length;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -23,6 +23,7 @@ import {
   LibraryLayout,
   PreviewChangesEmbed,
 } from './library-authoring';
+import { ProgramDetailPage } from './programs';
 import initializeStore from './store';
 import CourseAuthoringRoutes from './CourseAuthoringRoutes';
 import Head from './head/Head';
@@ -65,6 +66,8 @@ const App = () => {
     createRoutesFromElements(
       <Route>
         <Route path="/home" element={<StudioHome />} />
+        <Route path="/programs" element={<StudioHome />} />
+        <Route path="/programs/:programId" element={<ProgramDetailPage />} />
         <Route path="/libraries" element={<StudioHome />} />
         <Route path="/libraries-v1" element={<StudioHome />} />
         <Route path="/libraries-v1/migrate" element={<LegacyLibMigrationPage />} />

--- a/src/programs/ProgramDetailPage.tsx
+++ b/src/programs/ProgramDetailPage.tsx
@@ -1,0 +1,584 @@
+import React, { useContext } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useFormik } from 'formik';
+import * as Yup from 'yup';
+import CreatableSelectBase from 'react-select/creatable';
+import DatePicker from 'react-datepicker';
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Container,
+  Form,
+  Layout,
+  Row,
+  Col,
+  Stack,
+  StatefulButton,
+  Tab,
+  Tabs,
+} from '@openedx/paragon';
+import { useIntl, defineMessages } from '@edx/frontend-platform/i18n';
+import { StudioFooterSlot } from '@edx/frontend-component-footer';
+import Header from '../header';
+import { LoadingSpinner } from '../generic/Loading';
+import { ToastContext } from '../generic/toast-context';
+import { useProgramDetail, useUpdateProgram } from './data/apiHooks';
+import CoursesTab from './courses-tab/CoursesTab';
+import InstructorsTab from './instructors-tab/InstructorsTab';
+import EnrollmentTab from './enrollment-tab/EnrollmentTab';
+
+const messages = defineMessages({
+  backToPrograms: { id: 'programs.detail.back', defaultMessage: '← Back to Programs' },
+  configureSubtitle: { id: 'programs.detail.subtitle', defaultMessage: 'Configure your program details' },
+  saveProgram: { id: 'programs.detail.save', defaultMessage: 'Save Program' },
+  saving: { id: 'programs.detail.saving', defaultMessage: 'Saving...' },
+  savedSuccess: { id: 'programs.detail.saved', defaultMessage: 'Program saved successfully.' },
+  savedError: { id: 'programs.detail.error', defaultMessage: 'Failed to save program. Please try again.' },
+  notFound: { id: 'programs.detail.not-found', defaultMessage: 'Program not found.' },
+  tabDetails: { id: 'programs.detail.tab.details', defaultMessage: 'Program Details' },
+  tabCourses: { id: 'programs.detail.tab.courses', defaultMessage: 'Courses' },
+  tabInstructors: { id: 'programs.detail.tab.instructors', defaultMessage: 'Instructors' },
+  tabEnrollment: { id: 'programs.detail.tab.enrollment', defaultMessage: 'Enrollment' },
+  sectionBasicInfo: { id: 'programs.detail.section.basic', defaultMessage: 'Basic Information' },
+  sectionBasicSubtitle: { id: 'programs.detail.section.basic.sub', defaultMessage: 'Set the core details of your program' },
+  sectionImage: { id: 'programs.detail.section.image', defaultMessage: 'Program Card Image' },
+  sectionImageSubtitle: { id: 'programs.detail.section.image.sub', defaultMessage: 'Upload an image to represent your program in listings' },
+  sectionSummary: { id: 'programs.detail.section.summary', defaultMessage: 'Program Summary' },
+  unsavedBannerMessage: { id: 'programs.detail.unsaved.message', defaultMessage: 'You have unsaved changes.' },
+  unsavedBannerDiscard: { id: 'programs.detail.unsaved.discard', defaultMessage: 'Discard changes' },
+  unsavedBannerSave: { id: 'programs.detail.unsaved.save', defaultMessage: 'Save now' },
+  fieldTitle: { id: 'programs.detail.field.title', defaultMessage: 'Program Title' },
+  fieldTitleRequired: { id: 'programs.detail.field.title.required', defaultMessage: 'Program name is required.' },
+  fieldShortDesc: { id: 'programs.detail.field.short-desc', defaultMessage: 'Short Description' },
+  fieldShortDescHint: { id: 'programs.detail.field.short-desc.hint', defaultMessage: 'Appears in program listings and cards. Keep it concise.' },
+  fieldDetailedDesc: { id: 'programs.detail.field.long-desc', defaultMessage: 'Detailed Description' },
+  fieldDetailedDescHint: { id: 'programs.detail.field.long-desc.hint', defaultMessage: 'Appears on the program detail page. Provide comprehensive information.' },
+  fieldAudience: { id: 'programs.detail.field.audience', defaultMessage: 'Target Audience' },
+  fieldAudienceHint: { id: 'programs.detail.field.audience.hint', defaultMessage: 'Choose an existing type or type a new one to create it.' },
+  fieldAudiencePlaceholder: { id: 'programs.detail.field.audience.placeholder', defaultMessage: 'Select or add audience type...' },
+  fieldAudienceAdd: { id: 'programs.detail.field.audience.add', defaultMessage: 'Add "{value}"' },
+  fieldStartDate: { id: 'programs.detail.field.start-date', defaultMessage: 'Start Date' },
+  fieldEndDate: { id: 'programs.detail.field.end-date', defaultMessage: 'End Date' },
+  fieldStatus: { id: 'programs.detail.field.status', defaultMessage: 'Program Status' },
+  fieldFeatured: { id: 'programs.detail.field.featured', defaultMessage: 'Feature this program' },
+  fieldFeaturedHint: { id: 'programs.detail.field.featured.hint', defaultMessage: 'Featured programs are highlighted in the program catalog.' },
+  summaryOrg: { id: 'programs.detail.summary.org', defaultMessage: 'Organization' },
+  summaryType: { id: 'programs.detail.summary.type', defaultMessage: 'Program Type' },
+  summaryRun: { id: 'programs.detail.summary.run', defaultMessage: 'Program Run' },
+  summaryId: { id: 'programs.detail.summary.id', defaultMessage: 'Program ID' },
+  summaryNote: { id: 'programs.detail.summary.note', defaultMessage: 'These fields form the program\'s unique identifier and cannot be changed after creation.' },
+  imageUploadPrompt: { id: 'programs.detail.image.prompt', defaultMessage: 'Click to upload program image' },
+  imageUploadHint: { id: 'programs.detail.image.hint', defaultMessage: 'Recommended: 1280×720px · JPG or PNG' },
+  imageChange: { id: 'programs.detail.image.change', defaultMessage: 'Change Image' },
+});
+
+// ContentTagsCollapsible.d.ts globally augments react-select/base Props with taxonomy-specific
+// fields, which makes TypeScript require those props on every react-select usage in this project.
+// This cast is the recommended workaround noted in that file.
+const CreatableSelect = CreatableSelectBase as React.ComponentType<any>;
+
+const STATUS_OPTIONS = [
+  { value: 'draft', label: 'Draft' },
+  { value: 'active', label: 'Active' },
+  { value: 'archived', label: 'Archived' },
+  { value: 'freezed', label: 'Freezed' },
+];
+
+const STATUS_BADGE_VARIANT: Record<string, string> = {
+  draft: 'secondary',
+  active: 'success',
+  archived: 'dark',
+  freezed: 'light',
+};
+
+interface DateInputProps {
+  value?: string;
+  onClick?: () => void;
+  placeholder?: string;
+}
+
+// Wraps react-datepicker's custom input in a Paragon Form.Control so it inherits the design system styling.
+// onChange is a no-op because react-datepicker manages the value; readOnly is intentionally omitted so
+// Paragon does not apply its greyed-out disabled styling.
+const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
+  ({ value, onClick, placeholder }, ref) => (
+    <Form.Control
+      value={value ?? ''}
+      onClick={onClick}
+      onChange={() => {}}
+      ref={ref as React.Ref<HTMLInputElement>}
+      placeholder={placeholder}
+      style={{ cursor: 'pointer' }}
+    />
+  ),
+);
+
+// Label/value pair used in the read-only Program Summary card
+const SummaryField: React.FC<{ label: string; value: string; mono?: boolean }> = ({
+  label, value, mono = false,
+}) => (
+  <div className="mb-3">
+    <p className="x-small text-uppercase text-muted font-weight-bold mb-1 letter-spacing-wider">{label}</p>
+    <p className={`mb-0 ${mono ? 'text-monospace small' : ''}`}>{value}</p>
+  </div>
+);
+
+// Defined outside the component so React doesn't see a new type on every render
+const formatAudienceCreateLabel = (inputValue: string) => (
+  <span>
+    <strong style={{ color: '#0a58ca' }}>+ Add new audience type: </strong>
+    <em>&ldquo;{inputValue}&rdquo;</em>
+  </span>
+);
+
+const ProgramDetailPage: React.FC = () => {
+  const { programId } = useParams<{ programId: string }>();
+  const intl = useIntl();
+  const [activeTab, setActiveTab] = React.useState('details');
+  const [imageFile, setImageFile] = React.useState<File | null>(null);
+  const { showToast } = useContext(ToastContext);
+
+  const { data, isLoading, isError } = useProgramDetail(programId ?? '');
+  const { mutateAsync: updateProgram, isPending: isSaving } = useUpdateProgram();
+
+  const program = data?.program;
+  const availableAudiences = data?.availableAudiences ?? [];
+  const audienceOptions = availableAudiences.map((a) => ({ value: a, label: a }));
+
+  const formik = useFormik({
+    initialValues: {
+      displayName: program?.displayName ?? '',
+      targetAudience: program?.targetAudience ?? '',
+      shortDescription: program?.shortDescription ?? '',
+      longDescription: program?.longDescription ?? '',
+      status: program?.status ?? 'draft',
+      isFeatured: program?.isFeatured ?? false,
+      startDate: program?.startDate ?? '',
+      endDate: program?.endDate ?? '',
+      image: program?.image ?? '',
+    },
+    enableReinitialize: true,
+    validationSchema: Yup.object({
+      displayName: Yup.string().trim().required(intl.formatMessage(messages.fieldTitleRequired)),
+    }),
+    onSubmit: async (values) => {
+      try {
+        await updateProgram({ programId: programId ?? '', data: values, imageFile });
+        setImageFile(null);
+        showToast(intl.formatMessage(messages.savedSuccess));
+      } catch {
+        showToast(intl.formatMessage(messages.savedError));
+      }
+    },
+  });
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setImageFile(file);
+      // Keep blob URL in formik only for preview — actual File is in imageFile state
+      formik.setFieldValue('image', URL.createObjectURL(file));
+    }
+  };
+
+  const selectedAudience = formik.values.targetAudience
+    ? { value: formik.values.targetAudience, label: formik.values.targetAudience }
+    : null;
+
+  const statusBadgeVariant = STATUS_BADGE_VARIANT[formik.values.status ?? 'draft'] ?? 'secondary';
+  const statusLabel = STATUS_OPTIONS.find((o) => o.value === formik.values.status)?.label ?? 'Draft';
+
+  if (isLoading) {
+    return (
+      <>
+        <Header isHiddenMainMenu />
+        <Container size="xl" className="p-4 mt-3 d-flex justify-content-center">
+          <LoadingSpinner />
+        </Container>
+      </>
+    );
+  }
+
+  if (isError || !program) {
+    return (
+      <>
+        <Header isHiddenMainMenu />
+        <Container size="xl" className="p-4 mt-3">
+          <Alert variant="danger">{intl.formatMessage(messages.notFound)}</Alert>
+        </Container>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Header isHiddenMainMenu />
+      <Container size="xl" className="p-4 mt-3">
+
+        {/* ── Page header ─────────────────────────────────────────────── */}
+        <div className="d-flex justify-content-between align-items-start mb-4">
+          <div>
+            <Link to="/programs" className="small text-muted text-decoration-none">
+              {intl.formatMessage(messages.backToPrograms)}
+            </Link>
+            <h2 className="mt-1 mb-0 d-flex align-items-center gap-2">
+              {formik.values.displayName || program.displayName}
+              {formik.values.isFeatured && (
+                <Badge variant="primary" className="ml-2 align-middle" style={{ fontSize: '0.55em', verticalAlign: 'middle' }}>
+                  Featured
+                </Badge>
+              )}
+            </h2>
+            <p className="text-muted small mb-0">{intl.formatMessage(messages.configureSubtitle)}</p>
+          </div>
+          <StatefulButton
+            state={isSaving ? 'pending' : 'default'}
+            labels={{
+              default: intl.formatMessage(messages.saveProgram),
+              pending: intl.formatMessage(messages.saving),
+            }}
+            disabledStates={['pending']}
+            onClick={() => formik.handleSubmit()}
+            variant="primary"
+          />
+        </div>
+
+        {/* ── Unsaved changes banner ──────────────────────────────────── */}
+        {formik.dirty && !formik.isSubmitting && (
+          <Alert variant="warning" className="mb-3">
+            <div className="d-flex justify-content-between align-items-center">
+              <span>
+                <strong>{intl.formatMessage(messages.unsavedBannerMessage)}</strong>
+                {' '}Save or discard before leaving.
+              </span>
+              <Stack direction="horizontal" gap={2}>
+                <Button
+                  variant="outline-secondary"
+                  size="sm"
+                  onClick={() => formik.resetForm()}
+                  disabled={isSaving}
+                >
+                  {intl.formatMessage(messages.unsavedBannerDiscard)}
+                </Button>
+                <Button
+                  variant="warning"
+                  size="sm"
+                  onClick={() => formik.handleSubmit()}
+                  disabled={isSaving}
+                >
+                  {intl.formatMessage(messages.unsavedBannerSave)}
+                </Button>
+              </Stack>
+            </div>
+          </Alert>
+        )}
+
+        {/* ── Tabs ────────────────────────────────────────────────────── */}
+        <Tabs
+          variant="tabs"
+          activeKey={activeTab}
+          onSelect={(k) => setActiveTab(k ?? 'details')}
+        >
+          {/* Program Details ─────────────────────────────────────────── */}
+          <Tab eventKey="details" title={intl.formatMessage(messages.tabDetails)}>
+            <Layout
+              lg={[{ span: 8 }, { span: 4 }]}
+              md={[{ span: 8 }, { span: 4 }]}
+              sm={[{ span: 12 }, { span: 12 }]}
+              xs={[{ span: 12 }, { span: 12 }]}
+              xl={[{ span: 8 }, { span: 4 }]}
+              className="mt-4"
+            >
+              {/* ── Left column: editable fields ──────────────────────── */}
+              <Layout.Element>
+
+                {/* Basic Information card */}
+                <Card className="mb-4">
+                  <Card.Header
+                    title={intl.formatMessage(messages.sectionBasicInfo)}
+                    subtitle={intl.formatMessage(messages.sectionBasicSubtitle)}
+                  />
+                  <Card.Section>
+                    <Form onSubmit={formik.handleSubmit}>
+
+                      {/* Program Title */}
+                      <Form.Group
+                        isInvalid={formik.touched.displayName && !!formik.errors.displayName}
+                        className="mb-4"
+                      >
+                        <Form.Label>{intl.formatMessage(messages.fieldTitle)}</Form.Label>
+                        <Form.Control
+                          name="displayName"
+                          placeholder="e.g. Advanced Tax Assessment Program"
+                          value={formik.values.displayName}
+                          onChange={formik.handleChange}
+                          onBlur={formik.handleBlur}
+                        />
+                        {formik.touched.displayName && formik.errors.displayName && (
+                          <Form.Control.Feedback type="invalid">
+                            {formik.errors.displayName}
+                          </Form.Control.Feedback>
+                        )}
+                      </Form.Group>
+
+                      {/* Short Description */}
+                      <Form.Group className="mb-4">
+                        <Form.Label>{intl.formatMessage(messages.fieldShortDesc)}</Form.Label>
+                        <Form.Control
+                          as="textarea"
+                          rows={3}
+                          name="shortDescription"
+                          placeholder="Brief summary shown in listings and cards..."
+                          value={formik.values.shortDescription ?? ''}
+                          onChange={formik.handleChange}
+                          onBlur={formik.handleBlur}
+                        />
+                        <Form.Text muted>{intl.formatMessage(messages.fieldShortDescHint)}</Form.Text>
+                      </Form.Group>
+
+                      {/* Detailed Description */}
+                      <Form.Group className="mb-4">
+                        <Form.Label>{intl.formatMessage(messages.fieldDetailedDesc)}</Form.Label>
+                        <Form.Control
+                          as="textarea"
+                          rows={6}
+                          name="longDescription"
+                          placeholder="Comprehensive description for the program detail page..."
+                          value={formik.values.longDescription ?? ''}
+                          onChange={formik.handleChange}
+                          onBlur={formik.handleBlur}
+                        />
+                        <Form.Text muted>{intl.formatMessage(messages.fieldDetailedDescHint)}</Form.Text>
+                      </Form.Group>
+
+                      {/* Target Audience — creatable, case-insensitive */}
+                      <Form.Group className="mb-4">
+                        <Form.Label>{intl.formatMessage(messages.fieldAudience)}</Form.Label>
+                        <CreatableSelect
+                          isClearable
+                          options={audienceOptions}
+                          value={selectedAudience}
+                          onChange={(option) => formik.setFieldValue('targetAudience', option?.value ?? '')}
+                          onCreateOption={(inputValue) => formik.setFieldValue('targetAudience', inputValue)}
+                          isValidNewOption={(inputValue) => {
+                            if (!inputValue.trim()) { return false; }
+                            const normalized = inputValue.toLowerCase();
+                            return !audienceOptions.some((o) => o.value.toLowerCase() === normalized);
+                          }}
+                          formatCreateLabel={formatAudienceCreateLabel}
+                          placeholder={intl.formatMessage(messages.fieldAudiencePlaceholder)}
+                          styles={{
+                            control: (base, state) => ({
+                              ...base,
+                              minHeight: '38px',
+                              borderColor: state.isFocused ? '#0d6efd' : '#adb5bd',
+                              boxShadow: state.isFocused ? '0 0 0 1px #0d6efd' : 'none',
+                              '&:hover': { borderColor: '#0d6efd' },
+                            }),
+                            menu: (base) => ({ ...base, zIndex: 9999 }),
+                          }}
+                        />
+                        <Form.Text muted>{intl.formatMessage(messages.fieldAudienceHint)}</Form.Text>
+                      </Form.Group>
+
+                      {/* Start / End Dates */}
+                      <Row className="mb-4">
+                        <Col xs={12} md={6}>
+                          <Form.Group>
+                            <Form.Label>{intl.formatMessage(messages.fieldStartDate)}</Form.Label>
+                            <DatePicker
+                              selected={formik.values.startDate ? new Date(formik.values.startDate) : null}
+                              onChange={(date) => formik.setFieldValue('startDate', date ? date.toISOString().split('T')[0] : '')}
+                              customInput={<DateInput placeholder="Select start date" />}
+                              dateFormat="MMMM d, yyyy"
+                              popperPlacement="bottom-start"
+                              showMonthDropdown
+                              showYearDropdown
+                              dropdownMode="select"
+                              wrapperClassName="d-block mt-1"
+                            />
+                          </Form.Group>
+                        </Col>
+                        <Col xs={12} md={6}>
+                          <Form.Group>
+                            <Form.Label>{intl.formatMessage(messages.fieldEndDate)}</Form.Label>
+                            <DatePicker
+                              selected={formik.values.endDate ? new Date(formik.values.endDate) : null}
+                              onChange={(date) => formik.setFieldValue('endDate', date ? date.toISOString().split('T')[0] : '')}
+                              customInput={<DateInput placeholder="Select end date" />}
+                              dateFormat="MMMM d, yyyy"
+                              minDate={formik.values.startDate ? new Date(formik.values.startDate) : undefined}
+                              popperPlacement="bottom-start"
+                              showMonthDropdown
+                              showYearDropdown
+                              dropdownMode="select"
+                              wrapperClassName="d-block mt-1"
+                            />
+                          </Form.Group>
+                        </Col>
+                      </Row>
+
+                      {/* Program Status */}
+                      <Form.Group className="mb-4">
+                        <Form.Label>{intl.formatMessage(messages.fieldStatus)}</Form.Label>
+                        <Form.Control
+                          as="select"
+                          name="status"
+                          value={formik.values.status ?? 'draft'}
+                          onChange={formik.handleChange}
+                        >
+                          {STATUS_OPTIONS.map((opt) => (
+                            <option key={opt.value} value={opt.value}>{opt.label}</option>
+                          ))}
+                        </Form.Control>
+                      </Form.Group>
+
+                      {/* Is Featured */}
+                      <Form.Group className="mb-0">
+                        <div className="d-flex align-items-start">
+                          <input
+                            type="checkbox"
+                            id="isFeatured"
+                            checked={formik.values.isFeatured ?? false}
+                            onChange={(e) => formik.setFieldValue('isFeatured', e.target.checked)}
+                            className="mt-1 mr-2"
+                            style={{
+                              cursor: 'pointer', width: '16px', height: '16px', flexShrink: 0,
+                            }}
+                          />
+                          <div>
+                            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                            <label htmlFor="isFeatured" className="mb-0 font-weight-bold" style={{ cursor: 'pointer' }}>
+                              {intl.formatMessage(messages.fieldFeatured)}
+                            </label>
+                            <p className="small text-muted mb-0">{intl.formatMessage(messages.fieldFeaturedHint)}</p>
+                          </div>
+                        </div>
+                      </Form.Group>
+                    </Form>
+                  </Card.Section>
+                </Card>
+
+                {/* Program Card Image */}
+                <Card>
+                  <Card.Header
+                    title={intl.formatMessage(messages.sectionImage)}
+                    subtitle={intl.formatMessage(messages.sectionImageSubtitle)}
+                  />
+                  <Card.Section>
+                    {formik.values.image ? (
+                      <div>
+                        <img
+                          src={formik.values.image}
+                          alt="Program card"
+                          style={{
+                            width: '100%',
+                            maxHeight: '220px',
+                            objectFit: 'cover',
+                            borderRadius: '8px',
+                            display: 'block',
+                          }}
+                        />
+                        <Button
+                          variant="outline-primary"
+                          size="sm"
+                          className="mt-3"
+                          onClick={() => document.getElementById('program-image-input')?.click()}
+                        >
+                          {intl.formatMessage(messages.imageChange)}
+                        </Button>
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        className="w-100 border-0 bg-transparent p-0"
+                        style={{ cursor: 'pointer' }}
+                        onClick={() => document.getElementById('program-image-input')?.click()}
+                      >
+                        <div
+                          style={{
+                            border: '2px dashed #dee2e6',
+                            borderRadius: '8px',
+                            minHeight: '160px',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            gap: '8px',
+                            color: '#6c757d',
+                            transition: 'border-color 0.15s',
+                          }}
+                        >
+                          <span style={{ fontSize: '2.5em', lineHeight: 1 }}>🖼️</span>
+                          <span className="small font-weight-bold">
+                            {intl.formatMessage(messages.imageUploadPrompt)}
+                          </span>
+                          <span style={{ fontSize: '0.75em' }}>
+                            {intl.formatMessage(messages.imageUploadHint)}
+                          </span>
+                        </div>
+                      </button>
+                    )}
+                    <input
+                      id="program-image-input"
+                      type="file"
+                      accept="image/jpeg,image/png,image/webp"
+                      className="d-none"
+                      onChange={handleImageChange}
+                    />
+                  </Card.Section>
+                </Card>
+
+              </Layout.Element>
+
+              {/* ── Right column: read-only summary ───────────────────── */}
+              <Layout.Element>
+                <Card>
+                  <Card.Header
+                    title={intl.formatMessage(messages.sectionSummary)}
+                  />
+                  <Card.Section>
+
+                    {/* Status + featured badges */}
+                    <Stack direction="horizontal" gap={2} className="mb-4 flex-wrap">
+                      <Badge variant={statusBadgeVariant as any}>{statusLabel}</Badge>
+                      {formik.values.isFeatured && <Badge variant="primary">Featured</Badge>}
+                    </Stack>
+
+                    <SummaryField label={intl.formatMessage(messages.summaryOrg)} value={program.org} />
+                    <SummaryField label={intl.formatMessage(messages.summaryType)} value={program.programType} />
+                    <SummaryField label={intl.formatMessage(messages.summaryRun)} value={program.run} />
+                    <SummaryField label={intl.formatMessage(messages.summaryId)} value={program.id} mono />
+
+                    <Alert variant="info" className="small p-2 mb-0 mt-3">
+                      {intl.formatMessage(messages.summaryNote)}
+                    </Alert>
+
+                  </Card.Section>
+                </Card>
+              </Layout.Element>
+            </Layout>
+          </Tab>
+
+          <Tab eventKey="courses" title={intl.formatMessage(messages.tabCourses)}>
+            <CoursesTab program={program} programId={programId ?? ''} />
+          </Tab>
+
+          <Tab eventKey="instructors" title={intl.formatMessage(messages.tabInstructors)}>
+            <InstructorsTab program={program} />
+          </Tab>
+
+          <Tab eventKey="enrollment" title={intl.formatMessage(messages.tabEnrollment)}>
+            <EnrollmentTab programId={programId ?? ''} />
+          </Tab>
+        </Tabs>
+
+      </Container>
+      <StudioFooterSlot />
+    </>
+  );
+};
+
+export default ProgramDetailPage;

--- a/src/programs/courses-tab/AddCourseModal.test.tsx
+++ b/src/programs/courses-tab/AddCourseModal.test.tsx
@@ -1,0 +1,92 @@
+import {
+  fireEvent, initializeMocks, render, screen, waitFor,
+} from '@src/testUtils';
+import AddCourseModal from './AddCourseModal';
+import { mockCourse, mockPaginatedCourses } from '../data/api.mock';
+
+const mockAddMutate = jest.fn();
+const mockUseCourses = jest.fn();
+
+jest.mock('@src/programs/data/apiHooks', () => ({
+  useCourses: (...args: any[]) => mockUseCourses(...args),
+  useAddCourseToProgram: () => ({ mutateAsync: mockAddMutate, isPending: false }),
+}));
+
+const defaultProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+  programId: 'prog-key-1',
+  alreadyAddedIds: [],
+};
+
+describe('<AddCourseModal />', () => {
+  beforeEach(() => {
+    initializeMocks();
+    mockAddMutate.mockResolvedValue(undefined);
+    mockUseCourses.mockReturnValue({
+      data: mockPaginatedCourses([mockCourse()]),
+      isLoading: false,
+      isFetching: false,
+    });
+  });
+
+  it('renders course list when open', () => {
+    render(<AddCourseModal {...defaultProps} />);
+    expect(screen.getByText('Introduction to CS')).toBeInTheDocument();
+  });
+
+  it('shows "Added" badge for already-added course', () => {
+    const course = mockCourse({ id: 'already-added' });
+    mockUseCourses.mockReturnValue({
+      data: mockPaginatedCourses([course]),
+      isLoading: false,
+      isFetching: false,
+    });
+    render(<AddCourseModal {...defaultProps} alreadyAddedIds={['already-added']} />);
+    expect(screen.getByText('Added')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Add$/i })).not.toBeInTheDocument();
+  });
+
+  it('shows "Add" button for non-added course', () => {
+    render(<AddCourseModal {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /^Add$/i })).toBeInTheDocument();
+    expect(screen.queryByText('Added')).not.toBeInTheDocument();
+  });
+
+  it('calls addCourse with programId and courseId when Add is clicked', async () => {
+    const course = mockCourse({ id: 'course-v1:Org+X+2025' });
+    mockUseCourses.mockReturnValue({
+      data: mockPaginatedCourses([course]),
+      isLoading: false,
+      isFetching: false,
+    });
+    render(<AddCourseModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/i }));
+    await waitFor(() => expect(mockAddMutate).toHaveBeenCalledWith({
+      programId: 'prog-key-1',
+      courseId: 'course-v1:Org+X+2025',
+    }));
+  });
+
+  it('shows error alert when add mutation rejects', async () => {
+    mockAddMutate.mockRejectedValue(new Error('Failed'));
+    render(<AddCourseModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/i }));
+    expect(await screen.findByText(/Failed to add course/i)).toBeInTheDocument();
+  });
+
+  it('renders pagination when numPages > 1', () => {
+    mockUseCourses.mockReturnValue({
+      data: mockPaginatedCourses([mockCourse()], { numPages: 3 }),
+      isLoading: false,
+      isFetching: false,
+    });
+    render(<AddCourseModal {...defaultProps} />);
+    expect(screen.getByRole('navigation', { name: /Course list pagination/i })).toBeInTheDocument();
+  });
+
+  it('does not render pagination when numPages is 1', () => {
+    render(<AddCourseModal {...defaultProps} />);
+    expect(screen.queryByRole('navigation', { name: /Course list pagination/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/programs/courses-tab/AddCourseModal.tsx
+++ b/src/programs/courses-tab/AddCourseModal.tsx
@@ -1,0 +1,198 @@
+import React, {
+  useCallback, useEffect, useRef, useState,
+} from 'react';
+import {
+  ActionRow,
+  Alert,
+  Badge,
+  Button,
+  ModalDialog,
+  Pagination,
+  SearchField,
+  Spinner,
+} from '@openedx/paragon';
+import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
+import type { Course } from '../data/types';
+import { useCourses, useAddCourseToProgram } from '../data/apiHooks';
+
+const messages = defineMessages({
+  title: { id: 'programs.courses.modal.title', defaultMessage: 'Add Course to Program' },
+  subtitle: { id: 'programs.courses.modal.subtitle', defaultMessage: 'Select a course to add to your program' },
+  searchPlaceholder: { id: 'programs.courses.modal.search', defaultMessage: 'Search courses...' },
+  addBtn: { id: 'programs.courses.modal.add', defaultMessage: 'Add' },
+  addingBtn: { id: 'programs.courses.modal.adding', defaultMessage: 'Adding...' },
+  addedBadge: { id: 'programs.courses.modal.added', defaultMessage: 'Added' },
+  cancelBtn: { id: 'programs.courses.modal.cancel', defaultMessage: 'Cancel' },
+  noResults: { id: 'programs.courses.modal.no-results', defaultMessage: 'No courses match your search.' },
+  loading: { id: 'programs.courses.modal.loading', defaultMessage: 'Loading courses...' },
+  addError: { id: 'programs.courses.modal.add-error', defaultMessage: 'Failed to add course. Please try again.' },
+  paginationLabel: { id: 'programs.courses.modal.pagination', defaultMessage: 'Course list pagination' },
+});
+
+interface AddCourseModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  programId: string;
+  alreadyAddedIds: string[];
+}
+
+const CourseRow: React.FC<{
+  course: Course;
+  isAdded: boolean;
+  isAdding: boolean;
+  onAdd: (id: string) => void;
+  intl: ReturnType<typeof useIntl>;
+}> = ({
+  course, isAdded, isAdding, onAdd, intl,
+}) => (
+  <div
+    className="d-flex justify-content-between align-items-center py-3"
+    style={{ borderBottom: '1px solid #dee2e6' }}
+  >
+    <div>
+      <p className="mb-1 font-weight-bold">{course.displayName}</p>
+      <p className="mb-0 small text-muted">
+        {course.org}
+        {' · '}
+        {course.run}
+        {course.targetAudience && (
+          <>
+            {' · '}
+            {course.targetAudience}
+          </>
+        )}
+      </p>
+    </div>
+    {isAdded ? (
+      <Badge variant="success">{intl.formatMessage(messages.addedBadge)}</Badge>
+    ) : (
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={() => onAdd(course.id)}
+        disabled={isAdding}
+      >
+        {isAdding ? intl.formatMessage(messages.addingBtn) : intl.formatMessage(messages.addBtn)}
+      </Button>
+    )}
+  </div>
+);
+
+const AddCourseModal: React.FC<AddCourseModalProps> = ({
+  isOpen, onClose, programId, alreadyAddedIds,
+}) => {
+  const intl = useIntl();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [addingId, setAddingId] = useState<string | null>(null);
+  const [addError, setAddError] = useState(false);
+  const listRef = useRef<HTMLDivElement>(null);
+  const { data, isLoading, isFetching } = useCourses({ page: currentPage, search: searchQuery });
+  const { mutateAsync: addCourse } = useAddCourseToProgram();
+
+  useEffect(() => {
+    listRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [currentPage]);
+
+  const handleSearch = useCallback((q: string) => {
+    setSearchQuery(q);
+    setCurrentPage(1);
+  }, []);
+
+  const handleAdd = async (courseId: string) => {
+    setAddingId(courseId);
+    setAddError(false);
+    try {
+      await addCourse({ programId, courseId });
+    } catch {
+      setAddError(true);
+    } finally {
+      setAddingId(null);
+    }
+  };
+
+  const handleClose = () => {
+    setSearchQuery('');
+    setCurrentPage(1);
+    setAddError(false);
+    onClose();
+  };
+
+  return (
+    <ModalDialog
+      title={intl.formatMessage(messages.title)}
+      isOpen={isOpen}
+      onClose={handleClose}
+      size="lg"
+      hasCloseButton
+      isFullscreenOnMobile
+      isOverflowVisible={false}
+    >
+      <ModalDialog.Header style={{ zIndex: 9 }}>
+        <ModalDialog.Title>{intl.formatMessage(messages.title)}</ModalDialog.Title>
+        <p className="small text-muted mt-1 mb-3">{intl.formatMessage(messages.subtitle)}</p>
+        <SearchField
+          onSubmit={handleSearch}
+          onChange={handleSearch}
+          onClear={() => handleSearch('')}
+          value={searchQuery}
+          placeholder={intl.formatMessage(messages.searchPlaceholder)}
+        />
+      </ModalDialog.Header>
+
+      <ModalDialog.Body>
+        {addError && (
+          <Alert variant="danger" className="mb-3">
+            {intl.formatMessage(messages.addError)}
+          </Alert>
+        )}
+        {isLoading && (
+          <div className="d-flex justify-content-center py-4">
+            <Spinner animation="border" screenReaderText={intl.formatMessage(messages.loading)} />
+          </div>
+        )}
+        {!isLoading && (!data || data.results.length === 0) && !isFetching && (
+          <p className="text-muted text-center py-4">{intl.formatMessage(messages.noResults)}</p>
+        )}
+        {/* Scroll anchor so page changes bring the list top back into view */}
+        <div ref={listRef} />
+        <div style={{ opacity: isFetching && !isLoading ? 0.4 : 1, transition: 'opacity 0.15s' }}>
+          {!isLoading && data?.results.map((course) => (
+            <CourseRow
+              key={course.id}
+              course={course}
+              isAdded={alreadyAddedIds.includes(course.id)}
+              isAdding={addingId === course.id}
+              onAdd={handleAdd}
+              intl={intl}
+            />
+          ))}
+        </div>
+        {isFetching && !isLoading && (
+          <div className="d-flex justify-content-center py-2">
+            <Spinner animation="border" screenReaderText={intl.formatMessage(messages.loading)} />
+          </div>
+        )}
+        {data && data.numPages > 1 && (
+          <Pagination
+            paginationLabel={intl.formatMessage(messages.paginationLabel)}
+            pageCount={data.numPages}
+            currentPage={currentPage}
+            onPageSelect={(page: number) => setCurrentPage(page)}
+            className="mt-3"
+          />
+        )}
+      </ModalDialog.Body>
+
+      <ModalDialog.Footer>
+        <ActionRow>
+          <ModalDialog.CloseButton variant="tertiary">
+            {intl.formatMessage(messages.cancelBtn)}
+          </ModalDialog.CloseButton>
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
+  );
+};
+
+export default AddCourseModal;

--- a/src/programs/courses-tab/CoursesTab.test.tsx
+++ b/src/programs/courses-tab/CoursesTab.test.tsx
@@ -1,0 +1,101 @@
+import {
+  fireEvent, initializeMocks, render, screen, waitFor,
+} from '@src/testUtils';
+import CoursesTab from './CoursesTab';
+import { mockCourse, mockProgram } from '../data/api.mock';
+
+const mockRemoveMutate = jest.fn();
+
+jest.mock('@src/programs/data/apiHooks', () => ({
+  useRemoveCourseFromProgram: () => ({ mutateAsync: mockRemoveMutate, isPending: false }),
+  // AddCourseModal is rendered as a child; supply stubs so it doesn't throw
+  useCourses: () => ({ data: { results: [], count: 0, numPages: 1 }, isLoading: false, isFetching: false }),
+  useAddCourseToProgram: () => ({ mutateAsync: jest.fn(), isPending: false }),
+}));
+
+const programId = 'prog-key-1';
+
+describe('<CoursesTab />', () => {
+  beforeEach(() => {
+    initializeMocks();
+    mockRemoveMutate.mockResolvedValue(undefined);
+  });
+
+  it('renders empty state when program has no courses', () => {
+    const program = mockProgram({ courses: [] });
+    render(<CoursesTab program={program} programId={programId} />);
+    expect(screen.getByText(/No courses added yet/i)).toBeInTheDocument();
+  });
+
+  it('renders course list with name, org and run', () => {
+    const course = mockCourse({ displayName: 'My Course', org: 'MyOrg', run: '2025' });
+    const program = mockProgram({ courses: [course] });
+    render(<CoursesTab program={program} programId={programId} />);
+    expect(screen.getByText('My Course')).toBeInTheDocument();
+    expect(screen.getByText('MyOrg')).toBeInTheDocument();
+    expect(screen.getByText('2025')).toBeInTheDocument();
+  });
+
+  it('opens AddCourseModal when "Add Course" is clicked', () => {
+    const program = mockProgram({ courses: [] });
+    render(<CoursesTab program={program} programId={programId} />);
+    fireEvent.click(screen.getByRole('button', { name: /Add Course/i }));
+    expect(screen.getByText('Add Course to Program')).toBeInTheDocument();
+  });
+
+  it('opens confirmation dialog when Remove is clicked', () => {
+    const course = mockCourse({ displayName: 'Removable Course' });
+    const program = mockProgram({ courses: [course] });
+    render(<CoursesTab program={program} programId={programId} />);
+    fireEvent.click(screen.getByRole('button', { name: /Remove/i }));
+    expect(screen.getByText('Remove Course from Program?')).toBeInTheDocument();
+  });
+
+  it('shows course name and unenrollment warning in confirmation dialog', () => {
+    const course = mockCourse({ displayName: 'Removable Course' });
+    const program = mockProgram({ courses: [course] });
+    render(<CoursesTab program={program} programId={programId} />);
+    fireEvent.click(screen.getByRole('button', { name: /^Remove$/ }));
+    // Course name appears in both the row and the dialog description
+    expect(screen.getAllByText('Removable Course').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText(/unenroll all program learners/i)).toBeInTheDocument();
+  });
+
+  it('calls removeMutate with correct args when confirm is clicked', async () => {
+    const course = mockCourse({ id: 'course-v1:Org+X+2025' });
+    const program = mockProgram({ courses: [course] });
+    render(<CoursesTab program={program} programId={programId} />);
+    fireEvent.click(screen.getByRole('button', { name: /Remove/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Remove Course/i }));
+    await waitFor(() => expect(mockRemoveMutate).toHaveBeenCalledWith({
+      programId,
+      courseId: 'course-v1:Org+X+2025',
+    }));
+  });
+
+  it('closes dialog when Cancel is clicked', async () => {
+    const course = mockCourse();
+    const program = mockProgram({ courses: [course] });
+    render(<CoursesTab program={program} programId={programId} />);
+    fireEvent.click(screen.getByRole('button', { name: /Remove/i }));
+    expect(screen.getByText('Remove Course from Program?')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+    await waitFor(() => expect(screen.queryByText('Remove Course from Program?')).not.toBeInTheDocument());
+  });
+
+  it('disables all Remove buttons while confirmation is open', () => {
+    const courses = [
+      mockCourse({ id: 'c1', displayName: 'Course A' }),
+      mockCourse({ id: 'c2', displayName: 'Course B' }),
+    ];
+    const program = mockProgram({ courses });
+    render(<CoursesTab program={program} programId={programId} />);
+    const removeButtons = screen.getAllByRole('button', { name: /^Remove$/ });
+    fireEvent.click(removeButtons[0]);
+    // After confirmation opens, Paragon hides background via aria-hidden so
+    // we query with hidden:true to still find the now-disabled row buttons.
+    screen.getAllByRole('button', { name: /^Remove$/, hidden: true }).forEach((btn) => {
+      expect(btn).toBeDisabled();
+    });
+  });
+});

--- a/src/programs/courses-tab/CoursesTab.tsx
+++ b/src/programs/courses-tab/CoursesTab.tsx
@@ -1,0 +1,140 @@
+import React, { useState } from 'react';
+import {
+  Badge,
+  Button,
+  Stack,
+  useToggle,
+} from '@openedx/paragon';
+import { Add } from '@openedx/paragon/icons';
+import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
+import type { Course, Program } from '../data/types';
+import { useRemoveCourseFromProgram } from '../data/apiHooks';
+import DeleteModal from '../../generic/delete-modal/DeleteModal';
+import AddCourseModal from './AddCourseModal';
+
+const messages = defineMessages({
+  sectionTitle: { id: 'programs.courses.title', defaultMessage: 'Program Courses' },
+  sectionSubtitle: { id: 'programs.courses.subtitle', defaultMessage: 'Add and arrange courses for this program' },
+  addCourseBtn: { id: 'programs.courses.add-btn', defaultMessage: 'Add Course' },
+  emptyCourses: { id: 'programs.courses.empty', defaultMessage: 'No courses added yet. Click \'+ Add Course\' to begin.' },
+  removeBtn: { id: 'programs.courses.remove-btn', defaultMessage: 'Remove' },
+  confirmRemoveTitle: { id: 'programs.courses.confirm-remove.title', defaultMessage: 'Remove Course from Program?' },
+  confirmRemoveDesc: { id: 'programs.courses.confirm-remove.desc', defaultMessage: 'Removing this course will also unenroll all program learners from it. This cannot be undone.' },
+  confirmRemoveBtn: { id: 'programs.courses.confirm-remove.btn', defaultMessage: 'Remove Course' },
+});
+
+interface CoursesTabProps {
+  program: Program;
+  programId: string;
+}
+
+const CoursesTab: React.FC<CoursesTabProps> = ({ program, programId }) => {
+  const intl = useIntl();
+  const [isModalOpen, openModal, closeModal] = useToggle(false);
+  const [confirmCourseId, setConfirmCourseId] = useState<string | null>(null);
+  const removeCourse = useRemoveCourseFromProgram();
+
+  // program.courses is Course[] — full objects from the detail API response
+  const courses: Course[] = program.courses ?? [];
+  const courseIds = courses.map((c) => c.id);
+  const confirmCourse = courses.find((c) => c.id === confirmCourseId);
+
+  return (
+    <div className="mt-4">
+      {/* Section header */}
+      <div className="d-flex justify-content-between align-items-start mb-4">
+        <div>
+          <h3 className="mb-1">{intl.formatMessage(messages.sectionTitle)}</h3>
+          <p className="text-muted small mb-0">{intl.formatMessage(messages.sectionSubtitle)}</p>
+        </div>
+        <Button
+          variant="outline-primary"
+          iconBefore={Add}
+          size="sm"
+          onClick={openModal}
+        >
+          {intl.formatMessage(messages.addCourseBtn)}
+        </Button>
+      </div>
+
+      {/* Course list */}
+      {courses.length === 0 ? (
+        <p className="text-muted">{intl.formatMessage(messages.emptyCourses)}</p>
+      ) : (
+        <div>
+          {courses.map((course, index) => (
+            <div
+              key={course.id}
+              className="d-flex align-items-center py-3"
+              style={{ borderBottom: '1px solid #dee2e6' }}
+            >
+              {/* Index badge */}
+              <span
+                className="mr-3 font-weight-bold text-muted"
+                style={{
+                  width: '28px',
+                  height: '28px',
+                  borderRadius: '50%',
+                  background: '#f0f0f0',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  flexShrink: 0,
+                  fontSize: '0.8em',
+                }}
+              >
+                {index + 1}
+              </span>
+
+              {/* Course info */}
+              <div className="flex-grow-1">
+                <p className="mb-1 font-weight-bold">{course.displayName}</p>
+                <Stack direction="horizontal" gap={1} className="flex-wrap">
+                  <Badge variant="light">{course.org}</Badge>
+                  <Badge variant="light">{course.run}</Badge>
+                  {course.targetAudience && <Badge variant="light">{course.targetAudience}</Badge>}
+                </Stack>
+              </div>
+
+              <Button
+                variant="outline-danger"
+                size="sm"
+                onClick={() => setConfirmCourseId(course.id)}
+                disabled={confirmCourseId !== null}
+              >
+                {intl.formatMessage(messages.removeBtn)}
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <AddCourseModal
+        isOpen={isModalOpen}
+        onClose={closeModal}
+        programId={programId}
+        alreadyAddedIds={courseIds}
+      />
+
+      <DeleteModal
+        isOpen={!!confirmCourseId}
+        close={() => setConfirmCourseId(null)}
+        title={intl.formatMessage(messages.confirmRemoveTitle)}
+        description={(
+          <>
+            <strong>{confirmCourse?.displayName}</strong>
+            <br />
+            {intl.formatMessage(messages.confirmRemoveDesc)}
+          </>
+        )}
+        btnLabel={intl.formatMessage(messages.confirmRemoveBtn)}
+        onDeleteSubmit={async () => {
+          await removeCourse.mutateAsync({ programId, courseId: confirmCourseId! });
+          setConfirmCourseId(null);
+        }}
+      />
+    </div>
+  );
+};
+
+export default CoursesTab;

--- a/src/programs/data/api.mock.ts
+++ b/src/programs/data/api.mock.ts
@@ -1,0 +1,66 @@
+import type {
+  Batch, Course, Instructor, Learner, PaginatedCourses, PaginatedLearners, Program,
+} from './types';
+
+export const mockCourse = (overrides: Partial<Course> = {}): Course => ({
+  id: 'course-v1:TestOrg+CS101+2025',
+  displayName: 'Introduction to CS',
+  org: 'TestOrg',
+  run: '2025',
+  targetAudience: '',
+  ...overrides,
+});
+
+export const mockInstructor = (overrides: Partial<Instructor> = {}): Instructor => ({
+  id: 'prof.john',
+  username: 'prof.john',
+  email: 'john@example.com',
+  name: 'John Doe',
+  role: 'staff',
+  ...overrides,
+});
+
+export const mockLearner = (overrides: Partial<Learner> = {}): Learner => ({
+  id: 'student.alice',
+  username: 'student.alice',
+  email: 'alice@example.com',
+  name: 'Alice Smith',
+  ...overrides,
+});
+
+export const mockProgram = (overrides: Partial<Program> = {}): Program => ({
+  id: 'prog-key-1',
+  displayName: 'Test Program',
+  org: 'TestOrg',
+  programType: 'certificate',
+  run: '2025',
+  targetAudience: '',
+  courses: [],
+  ...overrides,
+});
+
+export const mockPaginatedCourses = (
+  results: Course[] = [mockCourse()],
+  overrides: Partial<PaginatedCourses> = {},
+): PaginatedCourses => ({
+  results,
+  count: results.length,
+  numPages: 1,
+  ...overrides,
+});
+
+export const mockPaginatedLearners = (
+  results: Learner[] = [mockLearner()],
+  overrides: Partial<PaginatedLearners> = {},
+): PaginatedLearners => ({
+  results,
+  count: results.length,
+  numPages: 1,
+  ...overrides,
+});
+
+export const mockBatch = (overrides: Partial<Batch> = {}): Batch => ({
+  id: '55',
+  name: 'Batch 55',
+  ...overrides,
+});

--- a/src/programs/data/api.ts
+++ b/src/programs/data/api.ts
@@ -1,0 +1,392 @@
+// When backend APIs are ready this is the ONLY file that changed.
+// All components call only the hooks in apiHooks.ts.
+
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import type {
+  Batch,
+  Course,
+  Instructor,
+  Learner,
+  PaginatedCourses,
+  PaginatedLearners,
+  Program,
+  ProgramConfig,
+  ProgramDetailResponse,
+} from './types';
+
+const getProgramsBaseUrl = () => `${getConfig().STUDIO_BASE_URL}/fbr/api/programs`;
+
+// ── Response → Course type transformation ────────────────────────────────────
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const toCourse = (d: any): Course => ({
+  id: d.course_key,
+  displayName: d.display_name,
+  org: d.org,
+  run: d.run,
+  targetAudience: d.target_audience?.name ?? '',
+});
+
+// ── Response → Program type transformation ──────────────────────────────────
+// SlugRelatedField serializes FK as string (short_name / slug), not an object.
+// target_audience is a FK returning {id, name}; target_audiences is the full list.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const toProgram = (d: any): Program => ({
+  id: d.program_key,
+  displayName: d.name,
+  org: d.organization,
+  programType: d.program_type,
+  run: d.batch,
+  targetAudience: d.target_audience?.name ?? '',
+  shortDescription: d.description ?? '',
+  longDescription: d.long_description ?? '',
+  status: d.status ?? 'draft',
+  isFeatured: d.is_featured ?? false,
+  startDate: d.start_date ?? '',
+  endDate: d.end_date ?? '',
+  image: d.card_image ?? '',
+  courses: d.courses?.map(toCourse) ?? [],
+});
+
+// ── Config — GET /fbr/api/programs/config/ ───────────────────────────────────
+export const getProgramsConfig = async (): Promise<ProgramConfig> => {
+  const { data } = await getAuthenticatedHttpClient().get(`${getProgramsBaseUrl()}/config/`);
+  return {
+    orgs: data.organizations.map((o: any) => ({ id: o.id, name: o.name, shortName: o.short_name })),
+    programTypes: data.program_types.map((t: any) => ({ id: t.id, name: t.name, slug: t.slug })),
+    // Statuses are stable constants; not returned by config endpoint
+    statuses: ['draft', 'active', 'archived', 'freezed'],
+  };
+};
+
+// ── List — GET /fbr/api/programs/ ────────────────────────────────────────────
+export const getPrograms = async (): Promise<Program[]> => {
+  const { data } = await getAuthenticatedHttpClient().get(`${getProgramsBaseUrl()}/`);
+  // Handle both paginated { results: [...] } and flat array responses
+  const results: any[] = Array.isArray(data) ? data : (data.results ?? []);
+  return results.map(toProgram);
+};
+
+// ── Detail — GET /fbr/api/programs/<program_key>/ ───────────────────────────
+export const getProgramDetail = async (programId: string): Promise<ProgramDetailResponse> => {
+  const { data } = await getAuthenticatedHttpClient().get(`${getProgramsBaseUrl()}/${programId}/`);
+  return {
+    program: toProgram(data),
+    // target_audiences in the detail response is the full list of all audiences system-wide
+    availableAudiences: (data.target_audiences ?? []).map((a: any) => a.name as string),
+  };
+};
+
+// ── Create — POST /fbr/api/programs/ ────────────────────────────────────────
+export const createProgram = async (input: Omit<Program, 'id'>): Promise<Program> => {
+  const payload = {
+    name: input.displayName,
+    organization: input.org,
+    program_type: input.programType,
+    batch: input.run,
+  };
+  const { data } = await getAuthenticatedHttpClient().post(`${getProgramsBaseUrl()}/`, payload);
+  return toProgram(data);
+};
+
+// ── Update — PATCH /fbr/api/programs/<program_key>/ ─────────────────────────
+// Always sent as multipart/form-data so card_image (ImageField) works.
+// imageFile is undefined when the user has not changed the image.
+export const updateProgram = async (
+  programId: string,
+  data: Partial<Program>,
+  imageFile?: File | null,
+): Promise<Program> => {
+  const formData = new FormData();
+
+  if (data.displayName !== undefined) { formData.append('name', data.displayName); }
+  if (data.shortDescription !== undefined) { formData.append('description', data.shortDescription ?? ''); }
+  if (data.longDescription !== undefined) { formData.append('long_description', data.longDescription ?? ''); }
+  if (data.status !== undefined) { formData.append('status', data.status ?? 'draft'); }
+  if (data.isFeatured !== undefined) { formData.append('is_featured', String(data.isFeatured)); }
+  if (data.startDate !== undefined) { formData.append('start_date', data.startDate ?? ''); }
+  if (data.endDate !== undefined) { formData.append('end_date', data.endDate ?? ''); }
+  if (data.targetAudience !== undefined) { formData.append('target_audience', data.targetAudience ?? ''); }
+  if (imageFile) { formData.append('card_image', imageFile); }
+
+  // Intentionally not sent: org / programType / run (immutable after creation)
+  //                         courses (separate API)
+
+  const { data: result } = await getAuthenticatedHttpClient().patch(
+    `${getProgramsBaseUrl()}/${programId}/`,
+    formData,
+  );
+  return toProgram(result);
+};
+
+// ── All platform courses — GET /fbr/api/programs/courses/ ───────────────────
+export interface GetCoursesParams {
+  page?: number;
+  search?: string;
+}
+
+export const getCourses = async (params: GetCoursesParams = {}): Promise<PaginatedCourses> => {
+  const pageSize = 5; // temporary — lower for pagination testing; revert to backend default
+  const { data } = await getAuthenticatedHttpClient().get(
+    `${getProgramsBaseUrl()}/courses/`,
+    { params: { page: params.page ?? 1, page_size: pageSize, ...(params.search ? { search: params.search } : {}) } },
+  );
+  const results: any[] = data.results ?? [];
+  const pagination = data.pagination ?? {};
+  const count = pagination.count ?? 0;
+  return {
+    results: results.map(toCourse),
+    count,
+    numPages: pagination.num_pages ?? (Math.ceil(count / pageSize) || 1),
+  };
+};
+
+// ── Add course to program — POST /fbr/api/programs/<key>/courses/ ────────────
+export const addCourseToProgram = async (programId: string, courseId: string): Promise<Course> => {
+  const { data } = await getAuthenticatedHttpClient().post(
+    `${getProgramsBaseUrl()}/${programId}/courses/`,
+    { course_id: courseId },
+  );
+  return toCourse(data);
+};
+
+// ── All target audiences — GET /fbr/api/programs/target-audiences/ ───────────
+export const getTargetAudiences = async (): Promise<string[]> => {
+  const { data } = await getAuthenticatedHttpClient().get(`${getProgramsBaseUrl()}/target-audiences/`);
+  return (data as any[]).map((a) => a.name as string);
+};
+
+// ── Course target audience — GET /fbr/api/programs/courses/<courseKey>/ ──────
+export const getCourseTargetAudience = async (courseKey: string): Promise<Course> => {
+  const { data } = await getAuthenticatedHttpClient().get(
+    `${getProgramsBaseUrl()}/courses/${encodeURIComponent(courseKey)}/`,
+  );
+  return toCourse(data);
+};
+
+// ── Update course target audience — PATCH /fbr/api/programs/courses/<key>/ ──
+export const updateCourseTargetAudience = async (
+  courseKey: string,
+  audienceName: string | null,
+): Promise<Course> => {
+  const { data } = await getAuthenticatedHttpClient().patch(
+    `${getProgramsBaseUrl()}/courses/${encodeURIComponent(courseKey)}/`,
+    { target_audience: audienceName },
+  );
+  return toCourse(data);
+};
+
+export interface GetInstructorsParams {
+  page?: number;
+  search?: string;
+}
+
+export interface GetLearnersParams {
+  page?: number;
+  search?: string;
+}
+
+// Shared mapping from UserSerializer response ({id, username, email, first_name, last_name})
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const toUser = (d: any): Learner => ({
+  id: d.username,
+  username: d.username,
+  email: d.email,
+  name: [d.first_name, d.last_name].filter(Boolean).join(' ') || d.username,
+});
+
+// ── Platform users — GET /fbr/api/programs/users/?role=instructor|learner ─────
+export const getPlatformUsers = async (
+  params: { role: 'instructor' | 'learner' } & GetLearnersParams,
+): Promise<PaginatedLearners> => {
+  const pageSize = 5;
+  const { data } = await getAuthenticatedHttpClient().get(
+    `${getProgramsBaseUrl()}/users/`,
+    {
+      params: {
+        role: params.role,
+        page: params.page ?? 1,
+        page_size: pageSize,
+        ...(params.search ? { search: params.search } : {}),
+      },
+    },
+  );
+  const pagination = data.pagination ?? {};
+  const count = pagination.count ?? 0;
+  return {
+    results: (data.results ?? []).map(toUser),
+    count,
+    numPages: pagination.num_pages ?? (Math.ceil(count / pageSize) || 1),
+  };
+};
+
+// ── Course team — GET ${STUDIO_BASE_URL}/api/contentstore/v1/course_team/<id> ─
+export const getCourseTeam = async (courseId: string): Promise<Instructor[]> => {
+  const { data } = await getAuthenticatedHttpClient().get(
+    `${getConfig().STUDIO_BASE_URL}/api/contentstore/v1/course_team/${courseId}`,
+  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (data.users ?? []).map((u: any) => ({
+    id: u.username,
+    username: u.username,
+    email: u.email,
+    role: u.role,
+    name: u.username,
+  }));
+};
+
+// ── Add instructor to course — POST ${STUDIO_BASE_URL}/course_team/<id>/<email>
+export const addInstructorToCourse = async (courseId: string, email: string): Promise<void> => {
+  await getAuthenticatedHttpClient().post(
+    `${getConfig().STUDIO_BASE_URL}/course_team/${courseId}/${email}`,
+    { role: 'staff' },
+  );
+};
+
+// ── Remove instructor from course — DELETE ${STUDIO_BASE_URL}/course_team/<id>/<email>
+export const removeInstructorFromCourse = async (courseId: string, email: string): Promise<void> => {
+  await getAuthenticatedHttpClient().delete(
+    `${getConfig().STUDIO_BASE_URL}/course_team/${courseId}/${email}`,
+  );
+};
+
+// ── Program enrollments — GET /fbr/api/programs/<key>/learners/ ───────────────
+// search param is wired but silently ignored until backend adds filter_backends
+export const getProgramEnrollments = async (
+  programId: string,
+  params: GetLearnersParams = {},
+): Promise<PaginatedLearners> => {
+  const pageSize = 5;
+  const { data } = await getAuthenticatedHttpClient().get(
+    `${getProgramsBaseUrl()}/${programId}/learners/`,
+    {
+      params: {
+        page: params.page ?? 1,
+        page_size: pageSize,
+        ...(params.search ? { search: params.search } : {}),
+      },
+    },
+  );
+  const pagination = data.pagination ?? {};
+  const count = pagination.count ?? 0;
+  return {
+    results: (data.results ?? []).map(toUser),
+    count,
+    numPages: pagination.num_pages ?? (Math.ceil(count / pageSize) || 1),
+  };
+};
+
+// ── Enroll learner in program — POST /fbr/api/programs/<key>/learners/ ────────
+export const enrollLearnerInProgram = async (programId: string, username: string): Promise<void> => {
+  await getAuthenticatedHttpClient().post(
+    `${getProgramsBaseUrl()}/${programId}/learners/`,
+    { username },
+  );
+};
+
+// ── Unenroll learner — DELETE /fbr/api/programs/<key>/learners/?username=... ──
+export const unenrollLearnerFromProgram = async (programId: string, username: string): Promise<void> => {
+  await getAuthenticatedHttpClient().delete(
+    `${getProgramsBaseUrl()}/${programId}/learners/`,
+    { params: { username } },
+  );
+};
+
+// ── Remove course from program — DELETE /fbr/api/programs/<key>/courses/ ──────
+export const removeCourseFromProgram = async (programId: string, courseId: string): Promise<void> => {
+  await getAuthenticatedHttpClient().delete(
+    `${getProgramsBaseUrl()}/${programId}/courses/`,
+    { params: { course_id: courseId } },
+  );
+};
+
+// ── MOCK: Batches — GET /fbr/api/programs/batches/ ───────────────────────────
+// MOCK — replace with real endpoint when backend ships
+
+const MOCK_BATCHES: Batch[] = [
+  { id: '55', name: 'Batch 55' },
+  { id: '54', name: 'Batch 54' },
+  { id: '53', name: 'Batch 53' },
+  { id: '52', name: 'Batch 52' },
+  { id: '51', name: 'Batch 51' },
+];
+
+const MOCK_BATCH_USERS: Record<string, Learner[]> = {
+  55: [
+    {
+      id: 'ahmed.riaz', username: 'ahmed.riaz', email: 'ahmed.riaz@batch55.pk', name: 'Ahmed Riaz',
+    },
+    {
+      id: 'sara.noor', username: 'sara.noor', email: 'sara.noor@batch55.pk', name: 'Sara Noor',
+    },
+    {
+      id: 'hassan.ali', username: 'hassan.ali', email: 'hassan.ali@batch55.pk', name: 'Hassan Ali',
+    },
+    {
+      id: 'fatima.malik', username: 'fatima.malik', email: 'fatima.malik@batch55.pk', name: 'Fatima Malik',
+    },
+  ],
+  54: [
+    {
+      id: 'usman.butt', username: 'usman.butt', email: 'usman.butt@batch54.pk', name: 'Usman Butt',
+    },
+    {
+      id: 'zainab.khan', username: 'zainab.khan', email: 'zainab.khan@batch54.pk', name: 'Zainab Khan',
+    },
+    {
+      id: 'tariq.nadeem', username: 'tariq.nadeem', email: 'tariq.nadeem@batch54.pk', name: 'Tariq Nadeem',
+    },
+  ],
+  53: [
+    {
+      id: 'bilal.siddiqui', username: 'bilal.siddiqui', email: 'bilal.s@batch53.pk', name: 'Bilal Siddiqui',
+    },
+    {
+      id: 'amna.qureshi', username: 'amna.qureshi', email: 'amna.q@batch53.pk', name: 'Amna Qureshi',
+    },
+    {
+      id: 'noman.haider', username: 'noman.haider', email: 'noman.h@batch53.pk', name: 'Noman Haider',
+    },
+    {
+      id: 'hina.baig', username: 'hina.baig', email: 'hina.baig@batch53.pk', name: 'Hina Baig',
+    },
+    {
+      id: 'shahzad.raza', username: 'shahzad.raza', email: 'shahzad.r@batch53.pk', name: 'Shahzad Raza',
+    },
+  ],
+  52: [
+    {
+      id: 'rabia.iqbal', username: 'rabia.iqbal', email: 'rabia.iqbal@batch52.pk', name: 'Rabia Iqbal',
+    },
+    {
+      id: 'kashif.rehman', username: 'kashif.rehman', email: 'kashif.r@batch52.pk', name: 'Kashif Rehman',
+    },
+    {
+      id: 'sadia.anwar', username: 'sadia.anwar', email: 'sadia.a@batch52.pk', name: 'Sadia Anwar',
+    },
+  ],
+  51: [
+    {
+      id: 'asim.chaudhry', username: 'asim.chaudhry', email: 'asim.c@batch51.pk', name: 'Asim Chaudhry',
+    },
+    {
+      id: 'maryam.hussain', username: 'maryam.hussain', email: 'maryam.h@batch51.pk', name: 'Maryam Hussain',
+    },
+    {
+      id: 'imtiaz.ali', username: 'imtiaz.ali', email: 'imtiaz.ali@batch51.pk', name: 'Imtiaz Ali',
+    },
+    {
+      id: 'shazia.sohail', username: 'shazia.sohail', email: 'shazia.s@batch51.pk', name: 'Shazia Sohail',
+    },
+  ],
+};
+
+export const getBatches = async (): Promise<Batch[]> => {
+  await new Promise<void>((res) => { setTimeout(res, 300); });
+  return MOCK_BATCHES;
+};
+
+export const getBatchUsers = async (batchId: string): Promise<Learner[]> => {
+  await new Promise<void>((res) => { setTimeout(res, 400); });
+  return MOCK_BATCH_USERS[batchId] ?? [];
+};

--- a/src/programs/data/apiHooks.ts
+++ b/src/programs/data/apiHooks.ts
@@ -1,0 +1,221 @@
+import {
+  useQuery, useMutation, useQueryClient, keepPreviousData,
+} from '@tanstack/react-query';
+import {
+  getProgramsConfig,
+  getPrograms,
+  getProgramDetail,
+  createProgram,
+  updateProgram,
+  getCourses,
+  addCourseToProgram,
+  getTargetAudiences,
+  getCourseTargetAudience,
+  updateCourseTargetAudience,
+  getPlatformUsers,
+  addInstructorToCourse,
+  removeInstructorFromCourse,
+  enrollLearnerInProgram,
+  unenrollLearnerFromProgram,
+  removeCourseFromProgram,
+  getCourseTeam,
+  getProgramEnrollments,
+  getBatches,
+  getBatchUsers,
+  type GetCoursesParams,
+  type GetInstructorsParams,
+  type GetLearnersParams,
+} from './api';
+import type { Program } from './types';
+
+export const useProgramsConfig = () => useQuery({
+  queryKey: ['programsConfig'],
+  queryFn: getProgramsConfig,
+});
+
+export const usePrograms = () => useQuery({
+  queryKey: ['programs'],
+  queryFn: getPrograms,
+});
+
+export const useProgramDetail = (programId: string) => useQuery({
+  queryKey: ['program', programId],
+  queryFn: () => getProgramDetail(programId),
+  enabled: !!programId,
+});
+
+export const useCreateProgram = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createProgram,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['programs'] });
+    },
+  });
+};
+
+export const useUpdateProgram = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      programId,
+      data,
+      imageFile,
+    }: { programId: string; data: Partial<Program>; imageFile?: File | null }) => (
+      updateProgram(programId, data, imageFile)
+    ),
+    onSuccess: (_, { programId }) => {
+      queryClient.invalidateQueries({ queryKey: ['programs'] });
+      queryClient.invalidateQueries({ queryKey: ['program', programId] });
+    },
+  });
+};
+
+export const useCourses = (params: GetCoursesParams = {}) => useQuery({
+  queryKey: ['courses', params.page ?? 1, params.search ?? ''],
+  queryFn: () => getCourses(params),
+  placeholderData: keepPreviousData,
+});
+
+export const useAddCourseToProgram = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ programId, courseId }: { programId: string; courseId: string }) => (
+      addCourseToProgram(programId, courseId)
+    ),
+    onSuccess: (_, { programId }) => {
+      queryClient.invalidateQueries({ queryKey: ['program', programId] });
+    },
+  });
+};
+
+export const useTargetAudiences = () => useQuery({
+  queryKey: ['targetAudiences'],
+  queryFn: getTargetAudiences,
+});
+
+export const useCourseTargetAudience = (courseId: string) => useQuery({
+  queryKey: ['courseTargetAudience', courseId],
+  queryFn: () => getCourseTargetAudience(courseId),
+  enabled: !!courseId,
+});
+
+export const useUpdateCourseTargetAudience = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      courseKey,
+      audienceName,
+    }: { courseKey: string; audienceName: string | null }) => (
+      updateCourseTargetAudience(courseKey, audienceName)
+    ),
+    onSuccess: (_, { courseKey }) => {
+      queryClient.invalidateQueries({ queryKey: ['courseTargetAudience', courseKey] });
+      queryClient.invalidateQueries({ queryKey: ['courses'] });
+    },
+  });
+};
+
+export const useInstructors = (params: GetInstructorsParams = {}, enabled = true) => useQuery({
+  queryKey: ['instructors', params.page ?? 1, params.search ?? ''],
+  queryFn: () => getPlatformUsers({ role: 'instructor', ...params }),
+  placeholderData: keepPreviousData,
+  staleTime: 0,
+  enabled,
+});
+
+export const useAddInstructorToCourse = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ courseId, email }: { courseId: string; email: string }) => (
+      addInstructorToCourse(courseId, email)
+    ),
+    onSuccess: (_, { courseId }) => {
+      queryClient.invalidateQueries({ queryKey: ['courseTeam', courseId] });
+    },
+  });
+};
+
+export const useRemoveInstructorFromCourse = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ courseId, email }: { courseId: string; email: string }) => (
+      removeInstructorFromCourse(courseId, email)
+    ),
+    onSuccess: (_, { courseId }) => {
+      queryClient.invalidateQueries({ queryKey: ['courseTeam', courseId] });
+    },
+  });
+};
+
+export const useLearners = (params: GetLearnersParams = {}, enabled = true) => useQuery({
+  queryKey: ['learners', params.page ?? 1, params.search ?? ''],
+  queryFn: () => getPlatformUsers({ role: 'learner', ...params }),
+  placeholderData: keepPreviousData,
+  staleTime: 0,
+  enabled,
+});
+
+export const useEnrollLearner = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ programId, username }: { programId: string; username: string }) => (
+      enrollLearnerInProgram(programId, username)
+    ),
+    onSuccess: (_, { programId }) => {
+      queryClient.invalidateQueries({ queryKey: ['programEnrollments', programId] });
+    },
+  });
+};
+
+export const useUnenrollLearner = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ programId, username }: { programId: string; username: string }) => (
+      unenrollLearnerFromProgram(programId, username)
+    ),
+    onSuccess: (_, { programId }) => {
+      queryClient.invalidateQueries({ queryKey: ['programEnrollments', programId] });
+    },
+  });
+};
+
+export const useRemoveCourseFromProgram = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ programId, courseId }: { programId: string; courseId: string }) => (
+      removeCourseFromProgram(programId, courseId)
+    ),
+    onSuccess: (_, { programId }) => {
+      queryClient.invalidateQueries({ queryKey: ['program', programId] });
+    },
+  });
+};
+
+export const useCourseTeam = (courseKey: string, enabled = true) => useQuery({
+  queryKey: ['courseTeam', courseKey],
+  queryFn: () => getCourseTeam(courseKey),
+  staleTime: 0,
+  enabled,
+});
+
+export const useProgramEnrollments = (programId: string, params: GetLearnersParams = {}) => useQuery({
+  queryKey: ['programEnrollments', programId, params.page ?? 1, params.search ?? ''],
+  queryFn: () => getProgramEnrollments(programId, params),
+  placeholderData: keepPreviousData,
+  staleTime: 0,
+});
+
+export const useBatches = (enabled = true) => useQuery({
+  queryKey: ['batches'],
+  queryFn: getBatches,
+  staleTime: Infinity,
+  enabled,
+});
+
+export const useBatchUsers = (batchId: string, enabled = true) => useQuery({
+  queryKey: ['batchUsers', batchId],
+  queryFn: () => getBatchUsers(batchId),
+  staleTime: Infinity,
+  enabled,
+});

--- a/src/programs/data/mock.ts
+++ b/src/programs/data/mock.ts
@@ -1,0 +1,96 @@
+import type { Course, Program } from './types';
+
+// Mutable — createProgram() and updateProgram() modify this in-place so
+// React Query cache invalidation returns updated data without a real API.
+export const AVAILABLE_AUDIENCES: string[] = ['Auditors', 'Inspectors', 'Clerks'];
+
+export const MOCK_COURSES: Course[] = [
+  {
+    id: 'course-001',
+    displayName: 'Tax Assessment Fundamentals',
+    org: 'IRSA Lahore',
+    run: '2024-Spring',
+    targetAudience: 'Inspectors',
+  },
+  {
+    id: 'course-002',
+    displayName: 'Advanced Audit Techniques',
+    org: 'IRSA Lahore',
+    run: '2024-Summer',
+    targetAudience: 'Auditors',
+  },
+  {
+    id: 'course-003',
+    displayName: 'Digital Tools for Revenue Administration',
+    org: 'IRSA Karachi',
+    run: '2024-Spring',
+    targetAudience: 'Clerks',
+  },
+  {
+    id: 'course-004',
+    displayName: 'Compliance and Legal Frameworks',
+    org: 'IRSA Lahore',
+    run: '2024-Fall',
+    targetAudience: 'Inspectors',
+  },
+  {
+    id: 'course-005',
+    displayName: 'Data Analysis for Tax Professionals',
+    org: 'IRSA Islamabad',
+    run: '2024-Summer',
+    targetAudience: 'Auditors',
+  },
+  {
+    id: 'course-006',
+    displayName: 'Customer Service in Public Administration',
+    org: 'IRSA Karachi',
+    run: '2024-Fall',
+    targetAudience: 'Clerks',
+  },
+];
+
+export const MOCK_PROGRAMS: Program[] = [
+  {
+    id: 'prog-001',
+    displayName: 'Advanced Tax Assessment Program',
+    org: 'IRSA Lahore',
+    programType: 'STP',
+    run: '2024-Q1',
+    targetAudience: 'Inspectors',
+    status: 'active',
+    isFeatured: true,
+    shortDescription: 'A comprehensive program for tax assessment professionals.',
+    longDescription: 'This program provides in-depth training on advanced tax assessment methodologies, equipping inspectors with the skills needed to handle complex cases effectively and in compliance with current regulations.',
+    startDate: '2024-01-15',
+    endDate: '2024-04-15',
+    courses: MOCK_COURSES.filter((c) => ['course-001', 'course-004'].includes(c.id)),
+  },
+  {
+    id: 'prog-002',
+    displayName: 'Digital Skills Training',
+    org: 'IRSA Lahore',
+    programType: 'DST',
+    run: '2024-Q2',
+    targetAudience: 'Clerks',
+    status: 'draft',
+    isFeatured: false,
+    shortDescription: 'Build essential digital skills for modern revenue administration.',
+    startDate: '2024-04-01',
+    endDate: '2024-06-30',
+    courses: MOCK_COURSES.filter((c) => c.id === 'course-003'),
+  },
+  {
+    id: 'prog-003',
+    displayName: 'Internal Services Training',
+    org: 'IRSA Lahore',
+    programType: 'IST',
+    run: '2024-Q3',
+    targetAudience: 'Auditors',
+    status: 'active',
+    isFeatured: false,
+    shortDescription: 'Enhance internal service delivery skills for auditing professionals.',
+    startDate: '2024-07-01',
+    endDate: '2024-09-30',
+    courses: [],
+  },
+];

--- a/src/programs/data/types.ts
+++ b/src/programs/data/types.ts
@@ -1,0 +1,86 @@
+export interface Course {
+  id: string;
+  displayName: string;
+  org: string;
+  run: string;
+  targetAudience: string;
+}
+
+export interface PaginatedCourses {
+  results: Course[];
+  count: number;
+  numPages: number;
+}
+
+export interface Program {
+  id: string;
+  displayName: string;
+  org: string;
+  programType: string;
+  run: string;
+  targetAudience: string;
+  shortDescription?: string;
+  longDescription?: string;
+  status?: string;
+  isFeatured?: boolean;
+  startDate?: string;
+  endDate?: string;
+  image?: string;
+  courses?: Course[];
+}
+
+export interface OrgOption {
+  id: number;
+  name: string;
+  shortName: string;
+}
+
+export interface ProgramTypeOption {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+export interface ProgramConfig {
+  orgs: OrgOption[];
+  programTypes: ProgramTypeOption[];
+  statuses: string[];
+}
+
+export interface ProgramDetailResponse {
+  program: Program;
+  /** All target audiences available system-wide — used for the dropdown options. */
+  availableAudiences: string[];
+}
+
+export interface Instructor {
+  id: string; // = username, kept for React key prop
+  username: string;
+  email: string;
+  name: string;
+  role?: string;
+}
+
+export interface PaginatedInstructors {
+  results: Instructor[];
+  count: number;
+  numPages: number;
+}
+
+export interface Learner {
+  id: string; // = username
+  username: string;
+  email: string;
+  name: string;
+}
+
+export interface PaginatedLearners {
+  results: Learner[];
+  count: number;
+  numPages: number;
+}
+
+export interface Batch {
+  id: string;
+  name: string;
+}

--- a/src/programs/enrollment-tab/AddLearnerModal.test.tsx
+++ b/src/programs/enrollment-tab/AddLearnerModal.test.tsx
@@ -1,0 +1,95 @@
+import {
+  fireEvent, initializeMocks, render, screen, waitFor,
+} from '@src/testUtils';
+import AddLearnerModal from './AddLearnerModal';
+import { mockLearner, mockPaginatedLearners } from '../data/api.mock';
+
+const mockEnrollMutate = jest.fn();
+const mockUseLearners = jest.fn();
+
+jest.mock('@src/programs/data/apiHooks', () => ({
+  useLearners: (...args: any[]) => mockUseLearners(...args),
+  useEnrollLearner: () => ({ mutateAsync: mockEnrollMutate, isPending: false }),
+}));
+
+const defaultProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+  programId: 'prog-key-1',
+  alreadyEnrolledIds: [],
+};
+
+describe('<AddLearnerModal />', () => {
+  beforeEach(() => {
+    initializeMocks();
+    mockEnrollMutate.mockResolvedValue(undefined);
+    mockUseLearners.mockReturnValue({
+      data: mockPaginatedLearners([mockLearner()]),
+      isLoading: false,
+      isFetching: false,
+    });
+  });
+
+  it('renders learner list when open', () => {
+    render(<AddLearnerModal {...defaultProps} />);
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+  });
+
+  it('shows "Enrolled" badge for already-enrolled learner', () => {
+    const learner = mockLearner({ id: 'student.alice', username: 'student.alice' });
+    mockUseLearners.mockReturnValue({
+      data: mockPaginatedLearners([learner]),
+      isLoading: false,
+      isFetching: false,
+    });
+    render(<AddLearnerModal {...defaultProps} alreadyEnrolledIds={['student.alice']} />);
+    expect(screen.getByText('Enrolled')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Enroll$/i })).not.toBeInTheDocument();
+  });
+
+  it('shows "Enroll" button for non-enrolled learner', () => {
+    render(<AddLearnerModal {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /^Enroll$/i })).toBeInTheDocument();
+  });
+
+  it('calls enrollLearner with programId and username when Enroll is clicked', async () => {
+    const learner = mockLearner({ id: 'student.alice', username: 'student.alice' });
+    mockUseLearners.mockReturnValue({
+      data: mockPaginatedLearners([learner]),
+      isLoading: false,
+      isFetching: false,
+    });
+    render(<AddLearnerModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /^Enroll$/i }));
+    await waitFor(() => expect(mockEnrollMutate).toHaveBeenCalledWith({
+      programId: 'prog-key-1',
+      username: 'student.alice',
+    }));
+  });
+
+  it('shows error alert when enrollment fails', async () => {
+    mockEnrollMutate.mockRejectedValue(new Error('Server error'));
+    render(<AddLearnerModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /^Enroll$/i }));
+    expect(await screen.findByText(/Failed to enroll learner/i)).toBeInTheDocument();
+  });
+
+  it('renders pagination when numPages > 1', () => {
+    mockUseLearners.mockReturnValue({
+      data: mockPaginatedLearners([mockLearner()], { numPages: 3 }),
+      isLoading: false,
+      isFetching: false,
+    });
+    render(<AddLearnerModal {...defaultProps} />);
+    expect(screen.getByRole('navigation', { name: /Learner list pagination/i })).toBeInTheDocument();
+  });
+
+  it('passes enabled=false to useLearners when modal is closed', () => {
+    render(<AddLearnerModal {...defaultProps} isOpen={false} />);
+    expect(mockUseLearners).toHaveBeenCalledWith(
+      expect.any(Object),
+      false,
+    );
+  });
+});

--- a/src/programs/enrollment-tab/AddLearnerModal.tsx
+++ b/src/programs/enrollment-tab/AddLearnerModal.tsx
@@ -1,0 +1,173 @@
+import React, {
+  useCallback, useEffect, useRef, useState,
+} from 'react';
+import {
+  ActionRow,
+  Alert,
+  Badge,
+  Button,
+  ModalDialog,
+  Pagination,
+  SearchField,
+  Spinner,
+} from '@openedx/paragon';
+import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
+import { useLearners, useEnrollLearner } from '../data/apiHooks';
+
+const messages = defineMessages({
+  title: { id: 'programs.enrollment.modal.title', defaultMessage: 'Enroll Learner in Program' },
+  subtitle: { id: 'programs.enrollment.modal.subtitle', defaultMessage: 'Select a learner to enroll in this program' },
+  searchPlaceholder: { id: 'programs.enrollment.modal.search', defaultMessage: 'Search learners...' },
+  enrollBtn: { id: 'programs.enrollment.modal.enroll', defaultMessage: 'Enroll' },
+  enrollingBtn: { id: 'programs.enrollment.modal.enrolling', defaultMessage: 'Enrolling...' },
+  enrolledBadge: { id: 'programs.enrollment.modal.enrolled', defaultMessage: 'Enrolled' },
+  cancelBtn: { id: 'programs.enrollment.modal.cancel', defaultMessage: 'Cancel' },
+  noResults: { id: 'programs.enrollment.modal.no-results', defaultMessage: 'No learners match your search.' },
+  loading: { id: 'programs.enrollment.modal.loading', defaultMessage: 'Loading learners...' },
+  enrollError: { id: 'programs.enrollment.modal.enroll-error', defaultMessage: 'Failed to enroll learner. Please try again.' },
+  paginationLabel: { id: 'programs.enrollment.modal.pagination', defaultMessage: 'Learner list pagination' },
+});
+
+interface AddLearnerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  programId: string;
+  alreadyEnrolledIds: string[];
+}
+
+const AddLearnerModal: React.FC<AddLearnerModalProps> = ({
+  isOpen, onClose, programId, alreadyEnrolledIds,
+}) => {
+  const intl = useIntl();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [enrollingId, setEnrollingId] = useState<string | null>(null);
+  const [enrollError, setEnrollError] = useState(false);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const { data, isLoading, isFetching } = useLearners({ page: currentPage, search: searchQuery }, isOpen);
+  const { mutateAsync: enrollLearner } = useEnrollLearner();
+
+  useEffect(() => {
+    listRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [currentPage]);
+
+  const handleSearch = useCallback((q: string) => {
+    setSearchQuery(q);
+    setCurrentPage(1);
+  }, []);
+
+  const handleEnroll = async (username: string) => {
+    setEnrollingId(username);
+    setEnrollError(false);
+    try {
+      await enrollLearner({ programId, username });
+    } catch {
+      setEnrollError(true);
+    } finally {
+      setEnrollingId(null);
+    }
+  };
+
+  const handleClose = () => {
+    setSearchQuery('');
+    setCurrentPage(1);
+    setEnrollError(false);
+    onClose();
+  };
+
+  return (
+    <ModalDialog
+      title={intl.formatMessage(messages.title)}
+      isOpen={isOpen}
+      onClose={handleClose}
+      size="lg"
+      hasCloseButton
+      isFullscreenOnMobile
+      isOverflowVisible={false}
+    >
+      <ModalDialog.Header style={{ zIndex: 9 }}>
+        <ModalDialog.Title>{intl.formatMessage(messages.title)}</ModalDialog.Title>
+        <p className="small text-muted mt-1 mb-3">{intl.formatMessage(messages.subtitle)}</p>
+        <SearchField
+          onSubmit={handleSearch}
+          onChange={handleSearch}
+          onClear={() => handleSearch('')}
+          value={searchQuery}
+          placeholder={intl.formatMessage(messages.searchPlaceholder)}
+        />
+      </ModalDialog.Header>
+
+      <ModalDialog.Body>
+        {enrollError && (
+          <Alert variant="danger" className="mb-3">
+            {intl.formatMessage(messages.enrollError)}
+          </Alert>
+        )}
+        {isLoading && (
+          <div className="d-flex justify-content-center py-4">
+            <Spinner animation="border" screenReaderText={intl.formatMessage(messages.loading)} />
+          </div>
+        )}
+        {!isLoading && (!data || data.results.length === 0) && !isFetching && (
+          <p className="text-muted text-center py-4">{intl.formatMessage(messages.noResults)}</p>
+        )}
+        <div ref={listRef} />
+        <div style={{ opacity: isFetching && !isLoading ? 0.4 : 1, transition: 'opacity 0.15s' }}>
+          {!isLoading && data?.results.map((learner) => {
+            const isEnrolled = alreadyEnrolledIds.includes(learner.id);
+            const isEnrolling = enrollingId === learner.id;
+            return (
+              <div
+                key={learner.id}
+                className="d-flex justify-content-between align-items-center py-3"
+                style={{ borderBottom: '1px solid #dee2e6' }}
+              >
+                <div>
+                  <p className="mb-1 font-weight-bold">{learner.name}</p>
+                  <p className="mb-0 small text-muted">{learner.email}</p>
+                </div>
+                {isEnrolled ? (
+                  <Badge variant="success">{intl.formatMessage(messages.enrolledBadge)}</Badge>
+                ) : (
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() => handleEnroll(learner.username)}
+                    disabled={isEnrolling || !!enrollingId}
+                  >
+                    {isEnrolling ? intl.formatMessage(messages.enrollingBtn) : intl.formatMessage(messages.enrollBtn)}
+                  </Button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+        {isFetching && !isLoading && (
+          <div className="d-flex justify-content-center py-2">
+            <Spinner animation="border" screenReaderText={intl.formatMessage(messages.loading)} />
+          </div>
+        )}
+        {data && data.numPages > 1 && (
+          <Pagination
+            paginationLabel={intl.formatMessage(messages.paginationLabel)}
+            pageCount={data.numPages}
+            currentPage={currentPage}
+            onPageSelect={(page: number) => setCurrentPage(page)}
+            className="mt-3"
+          />
+        )}
+      </ModalDialog.Body>
+
+      <ModalDialog.Footer>
+        <ActionRow>
+          <ModalDialog.CloseButton variant="tertiary">
+            {intl.formatMessage(messages.cancelBtn)}
+          </ModalDialog.CloseButton>
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
+  );
+};
+
+export default AddLearnerModal;

--- a/src/programs/enrollment-tab/EnrollBatchModal.tsx
+++ b/src/programs/enrollment-tab/EnrollBatchModal.tsx
@@ -1,0 +1,214 @@
+import React, {
+  useCallback, useEffect, useState,
+} from 'react';
+import {
+  ActionRow,
+  Alert,
+  Badge,
+  Button,
+  Form,
+  ModalDialog,
+  Spinner,
+} from '@openedx/paragon';
+import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
+import { useBatches, useBatchUsers, useEnrollLearner } from '../data/apiHooks';
+
+const messages = defineMessages({
+  title: { id: 'programs.enrollment.batch.title', defaultMessage: 'Enroll Batch' },
+  subtitle: { id: 'programs.enrollment.batch.subtitle', defaultMessage: 'Select a batch to enroll all its learners into this program' },
+  batchSelectLabel: { id: 'programs.enrollment.batch.select-label', defaultMessage: 'Select Batch' },
+  batchSelectPlaceholder: { id: 'programs.enrollment.batch.select-placeholder', defaultMessage: '-- Select a batch --' },
+  loadingBatches: { id: 'programs.enrollment.batch.loading-batches', defaultMessage: 'Loading batches...' },
+  loadingUsers: { id: 'programs.enrollment.batch.loading-users', defaultMessage: 'Loading batch learners...' },
+  enrolledBadge: { id: 'programs.enrollment.batch.enrolled', defaultMessage: 'Enrolled' },
+  enrollAllBtn: { id: 'programs.enrollment.batch.enroll-all', defaultMessage: 'Enroll All' },
+  enrollingAllBtn: { id: 'programs.enrollment.batch.enrolling-all', defaultMessage: 'Enrolling...' },
+  enrolledAllSuccess: { id: 'programs.enrollment.batch.success', defaultMessage: 'All learners enrolled successfully.' },
+  enrollError: { id: 'programs.enrollment.batch.error', defaultMessage: 'Some enrollments failed. Please try again.' },
+  cancelBtn: { id: 'programs.enrollment.batch.cancel', defaultMessage: 'Cancel' },
+  noBatchUsers: { id: 'programs.enrollment.batch.no-users', defaultMessage: 'No learners found in this batch.' },
+  selectBatchPrompt: { id: 'programs.enrollment.batch.prompt', defaultMessage: 'Select a batch above to see its learners.' },
+});
+
+interface EnrollBatchModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  programId: string;
+  alreadyEnrolledIds: string[];
+}
+
+const EnrollBatchModal: React.FC<EnrollBatchModalProps> = ({
+  isOpen, onClose, programId, alreadyEnrolledIds,
+}) => {
+  const intl = useIntl();
+  const [selectedBatchId, setSelectedBatchId] = useState('');
+  const [isEnrollingAll, setIsEnrollingAll] = useState(false);
+  const [enrollSuccess, setEnrollSuccess] = useState(false);
+  const [enrollError, setEnrollError] = useState(false);
+
+  const { data: batches, isLoading: isBatchesLoading } = useBatches(isOpen);
+  const { data: batchUsers, isLoading: isUsersLoading } = useBatchUsers(selectedBatchId, !!selectedBatchId);
+  const { mutateAsync: enrollLearner } = useEnrollLearner();
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedBatchId('');
+      setIsEnrollingAll(false);
+      setEnrollSuccess(false);
+      setEnrollError(false);
+    }
+  }, [isOpen]);
+
+  const unenrolledUsers = batchUsers?.filter((u) => !alreadyEnrolledIds.includes(u.id)) ?? [];
+
+  const handleEnrollAll = useCallback(async () => {
+    setIsEnrollingAll(true);
+    setEnrollError(false);
+    setEnrollSuccess(false);
+    let anyFailed = false;
+    for (const user of unenrolledUsers) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await enrollLearner({ programId, username: user.username });
+      } catch {
+        anyFailed = true;
+      }
+    }
+    setIsEnrollingAll(false);
+    if (anyFailed) {
+      setEnrollError(true);
+    } else {
+      setEnrollSuccess(true);
+    }
+  }, [unenrolledUsers, enrollLearner, programId]);
+
+  const handleClose = () => {
+    setSelectedBatchId('');
+    setIsEnrollingAll(false);
+    setEnrollSuccess(false);
+    setEnrollError(false);
+    onClose();
+  };
+
+  return (
+    <ModalDialog
+      title={intl.formatMessage(messages.title)}
+      isOpen={isOpen}
+      onClose={handleClose}
+      size="lg"
+      hasCloseButton
+      isFullscreenOnMobile
+      isOverflowVisible={false}
+    >
+      <ModalDialog.Header style={{ zIndex: 9 }}>
+        <ModalDialog.Title>{intl.formatMessage(messages.title)}</ModalDialog.Title>
+        <p className="small text-muted mt-1 mb-3">{intl.formatMessage(messages.subtitle)}</p>
+        {isBatchesLoading ? (
+          <div className="d-flex align-items-center py-2">
+            <Spinner animation="border" size="sm" screenReaderText={intl.formatMessage(messages.loadingBatches)} />
+            <span className="ml-2 small text-muted">{intl.formatMessage(messages.loadingBatches)}</span>
+          </div>
+        ) : (
+          <Form.Group className="mb-0">
+            <Form.Label>{intl.formatMessage(messages.batchSelectLabel)}</Form.Label>
+            <Form.Control
+              as="select"
+              value={selectedBatchId}
+              onChange={(e) => {
+                setSelectedBatchId((e as React.ChangeEvent<HTMLSelectElement>).target.value);
+                setEnrollSuccess(false);
+                setEnrollError(false);
+              }}
+            >
+              <option value="">{intl.formatMessage(messages.batchSelectPlaceholder)}</option>
+              {(batches ?? []).map((batch) => (
+                <option key={batch.id} value={batch.id}>{batch.name}</option>
+              ))}
+            </Form.Control>
+          </Form.Group>
+        )}
+      </ModalDialog.Header>
+
+      <ModalDialog.Body>
+        {enrollSuccess && (
+          <Alert variant="success" className="mb-3">
+            {intl.formatMessage(messages.enrolledAllSuccess)}
+          </Alert>
+        )}
+        {enrollError && (
+          <Alert variant="danger" className="mb-3">
+            {intl.formatMessage(messages.enrollError)}
+          </Alert>
+        )}
+
+        {!selectedBatchId && (
+          <p className="text-muted text-center py-4">{intl.formatMessage(messages.selectBatchPrompt)}</p>
+        )}
+
+        {selectedBatchId && isUsersLoading && (
+          <div className="d-flex justify-content-center py-4">
+            <Spinner animation="border" screenReaderText={intl.formatMessage(messages.loadingUsers)} />
+          </div>
+        )}
+
+        {selectedBatchId && !isUsersLoading && batchUsers?.length === 0 && (
+          <p className="text-muted text-center py-4">{intl.formatMessage(messages.noBatchUsers)}</p>
+        )}
+
+        {selectedBatchId && !isUsersLoading && batchUsers && batchUsers.length > 0 && (
+          <>
+            <div className="d-flex justify-content-between align-items-center mb-3">
+              <p className="mb-0 text-muted small">
+                {batchUsers.length}
+                {' '}
+                learners ·
+                {' '}
+                {alreadyEnrolledIds.filter((id) => batchUsers.some((u) => u.id === id)).length}
+                {' '}
+                already enrolled
+              </p>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleEnrollAll}
+                disabled={isEnrollingAll || unenrolledUsers.length === 0}
+              >
+                {isEnrollingAll
+                  ? intl.formatMessage(messages.enrollingAllBtn)
+                  : intl.formatMessage(messages.enrollAllBtn)}
+              </Button>
+            </div>
+            {batchUsers.map((user) => {
+              const isEnrolled = alreadyEnrolledIds.includes(user.id);
+              return (
+                <div
+                  key={user.id}
+                  className="d-flex justify-content-between align-items-center py-3"
+                  style={{ borderBottom: '1px solid #dee2e6' }}
+                >
+                  <div>
+                    <p className="mb-1 font-weight-bold">{user.name}</p>
+                    <p className="mb-0 small text-muted">{user.email}</p>
+                  </div>
+                  {isEnrolled && (
+                    <Badge variant="success">{intl.formatMessage(messages.enrolledBadge)}</Badge>
+                  )}
+                </div>
+              );
+            })}
+          </>
+        )}
+      </ModalDialog.Body>
+
+      <ModalDialog.Footer>
+        <ActionRow>
+          <ModalDialog.CloseButton variant="tertiary">
+            {intl.formatMessage(messages.cancelBtn)}
+          </ModalDialog.CloseButton>
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
+  );
+};
+
+export default EnrollBatchModal;

--- a/src/programs/enrollment-tab/EnrollmentTab.test.tsx
+++ b/src/programs/enrollment-tab/EnrollmentTab.test.tsx
@@ -1,0 +1,111 @@
+import {
+  fireEvent, initializeMocks, render, screen, waitFor,
+} from '@src/testUtils';
+import EnrollmentTab from './EnrollmentTab';
+import { mockLearner, mockPaginatedLearners } from '../data/api.mock';
+
+const mockUnenrollMutate = jest.fn();
+const mockUseProgramEnrollments = jest.fn();
+
+jest.mock('@src/programs/data/apiHooks', () => ({
+  useProgramEnrollments: (...args: any[]) => mockUseProgramEnrollments(...args),
+  useUnenrollLearner: () => ({ mutateAsync: mockUnenrollMutate, isPending: false }),
+  // hooks used by child modals — supply minimal stubs
+  useLearners: () => ({ data: { results: [], count: 0, numPages: 1 }, isLoading: false, isFetching: false }),
+  useEnrollLearner: () => ({ mutateAsync: jest.fn(), isPending: false }),
+  useBatches: () => ({ data: [], isLoading: false }),
+  useBatchUsers: () => ({ data: [], isLoading: false }),
+}));
+
+const programId = 'prog-key-1';
+
+describe('<EnrollmentTab />', () => {
+  beforeEach(() => {
+    initializeMocks();
+    mockUnenrollMutate.mockResolvedValue(undefined);
+    mockUseProgramEnrollments.mockReturnValue({
+      data: mockPaginatedLearners([mockLearner()]),
+      isLoading: false,
+      isFetching: false,
+    });
+  });
+
+  it('renders enrolled learner list with name and email', () => {
+    render(<EnrollmentTab programId={programId} />);
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+  });
+
+  it('shows empty state message when no learners enrolled', () => {
+    mockUseProgramEnrollments.mockReturnValue({
+      data: mockPaginatedLearners([], { count: 0 }),
+      isLoading: false,
+      isFetching: false,
+    });
+    render(<EnrollmentTab programId={programId} />);
+    expect(screen.getByText(/No learners enrolled yet/i)).toBeInTheDocument();
+  });
+
+  it('renders search field', () => {
+    render(<EnrollmentTab programId={programId} />);
+    expect(screen.getByPlaceholderText(/Search enrolled learners/i)).toBeInTheDocument();
+  });
+
+  it('passes search query to useProgramEnrollments', () => {
+    render(<EnrollmentTab programId={programId} />);
+    const searchInput = screen.getByPlaceholderText(/Search enrolled learners/i);
+    fireEvent.change(searchInput, { target: { value: 'alice' } });
+    expect(mockUseProgramEnrollments).toHaveBeenCalledWith(
+      programId,
+      expect.objectContaining({ search: 'alice' }),
+    );
+  });
+
+  it('opens confirmation dialog when Unenroll is clicked', () => {
+    render(<EnrollmentTab programId={programId} />);
+    fireEvent.click(screen.getByRole('button', { name: /Unenroll/i }));
+    expect(screen.getByText('Unenroll Learner?')).toBeInTheDocument();
+  });
+
+  it('shows learner name in confirmation dialog', () => {
+    const learner = mockLearner({ name: 'Bob Jones', username: 'bob.jones' });
+    mockUseProgramEnrollments.mockReturnValue({
+      data: mockPaginatedLearners([learner]),
+      isLoading: false,
+      isFetching: false,
+    });
+    render(<EnrollmentTab programId={programId} />);
+    fireEvent.click(screen.getByRole('button', { name: /Unenroll/i }));
+    // Name appears in dialog heading — findAllByText handles > 1 match (row + dialog)
+    expect(screen.getAllByText('Bob Jones').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows bold warning text in confirmation dialog', () => {
+    render(<EnrollmentTab programId={programId} />);
+    fireEvent.click(screen.getByRole('button', { name: /Unenroll/i }));
+    const warning = screen.getByText(/All enrollment data will be lost/i);
+    expect(warning.tagName).toBe('STRONG');
+  });
+
+  it('calls unenrollMutate with programId and username when confirm is clicked', async () => {
+    const learner = mockLearner({ username: 'student.alice' });
+    mockUseProgramEnrollments.mockReturnValue({
+      data: mockPaginatedLearners([learner]),
+      isLoading: false,
+      isFetching: false,
+    });
+    render(<EnrollmentTab programId={programId} />);
+    fireEvent.click(screen.getByRole('button', { name: /Unenroll/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Unenroll$/i }));
+    await waitFor(() => expect(mockUnenrollMutate).toHaveBeenCalledWith({
+      programId,
+      username: 'student.alice',
+    }));
+  });
+
+  it('opens AddLearnerModal when "Enroll Learner" is clicked', () => {
+    render(<EnrollmentTab programId={programId} />);
+    fireEvent.click(screen.getByRole('button', { name: /Enroll Learner/i }));
+    expect(screen.getByText('Enroll Learner in Program')).toBeInTheDocument();
+  });
+});

--- a/src/programs/enrollment-tab/EnrollmentTab.tsx
+++ b/src/programs/enrollment-tab/EnrollmentTab.tsx
@@ -1,0 +1,212 @@
+import React, { useState, useCallback } from 'react';
+import {
+  Badge,
+  Button,
+  Pagination,
+  SearchField,
+  Spinner,
+  Stack,
+  useToggle,
+} from '@openedx/paragon';
+import { Add } from '@openedx/paragon/icons';
+import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
+import { useProgramEnrollments, useUnenrollLearner } from '../data/apiHooks';
+import DeleteModal from '../../generic/delete-modal/DeleteModal';
+import AddLearnerModal from './AddLearnerModal';
+import EnrollBatchModal from './EnrollBatchModal';
+
+const messages = defineMessages({
+  sectionTitle: { id: 'programs.enrollment.title', defaultMessage: 'Learner Enrollment' },
+  sectionSubtitle: { id: 'programs.enrollment.subtitle', defaultMessage: 'Enroll learners into this program' },
+  enrollLearnerBtn: { id: 'programs.enrollment.add-btn', defaultMessage: 'Enroll Learner' },
+  enrollBatchBtn: { id: 'programs.enrollment.batch-btn', defaultMessage: 'Enroll Batch' },
+  searchPlaceholder: { id: 'programs.enrollment.search', defaultMessage: 'Search enrolled learners...' },
+  loading: { id: 'programs.enrollment.loading', defaultMessage: 'Loading enrolled learners...' },
+  emptyEnrollment: { id: 'programs.enrollment.empty', defaultMessage: 'No learners enrolled yet. Click \'+ Enroll Learner\' to begin.' },
+  noResults: { id: 'programs.enrollment.no-results', defaultMessage: 'No enrolled learners match your search.' },
+  paginationLabel: { id: 'programs.enrollment.pagination', defaultMessage: 'Enrolled learner list pagination' },
+  unenrollBtn: { id: 'programs.enrollment.unenroll-btn', defaultMessage: 'Unenroll' },
+  confirmUnenrollTitle: { id: 'programs.enrollment.confirm-unenroll.title', defaultMessage: 'Unenroll Learner?' },
+  confirmUnenrollDesc: {
+    id: 'programs.enrollment.confirm-unenroll.desc',
+    defaultMessage: 'This learner will be unenrolled from the program and all its courses. This action cannot be reverted.',
+  },
+  confirmUnenrollWarning: {
+    id: 'programs.enrollment.confirm-unenroll.warning',
+    defaultMessage: 'All enrollment data will be lost.',
+  },
+  confirmUnenrollBtn: { id: 'programs.enrollment.confirm-unenroll.btn', defaultMessage: 'Unenroll' },
+});
+
+interface EnrollmentTabProps {
+  programId: string;
+}
+
+const EnrollmentTab: React.FC<EnrollmentTabProps> = ({ programId }) => {
+  const intl = useIntl();
+  const [isModalOpen, openModal, closeModal] = useToggle(false);
+  const [isBatchModalOpen, openBatchModal, closeBatchModal] = useToggle(false);
+  const [enrolledSearch, setEnrolledSearch] = useState('');
+  const [enrolledPage, setEnrolledPage] = useState(1);
+  const [confirmUnenrollUsername, setConfirmUnenrollUsername] = useState<string | null>(null);
+
+  const { data, isLoading, isFetching } = useProgramEnrollments(
+    programId,
+    { page: enrolledPage, search: enrolledSearch },
+  );
+  const unenrollLearner = useUnenrollLearner();
+
+  const enrolledIds = data?.results.map((l) => l.id) ?? [];
+  const confirmLearner = data?.results.find((l) => l.username === confirmUnenrollUsername);
+
+  const handleSearch = useCallback((q: string) => {
+    setEnrolledSearch(q);
+    setEnrolledPage(1);
+  }, []);
+
+  return (
+    <div className="mt-4">
+      <div className="d-flex justify-content-between align-items-start mb-4">
+        <div>
+          <h3 className="mb-1">{intl.formatMessage(messages.sectionTitle)}</h3>
+          <p className="text-muted small mb-0">{intl.formatMessage(messages.sectionSubtitle)}</p>
+        </div>
+        <Stack direction="horizontal" gap={2}>
+          <Button
+            variant="outline-primary"
+            iconBefore={Add}
+            size="sm"
+            onClick={openBatchModal}
+          >
+            {intl.formatMessage(messages.enrollBatchBtn)}
+          </Button>
+          <Button
+            variant="outline-primary"
+            iconBefore={Add}
+            size="sm"
+            onClick={openModal}
+          >
+            {intl.formatMessage(messages.enrollLearnerBtn)}
+          </Button>
+        </Stack>
+      </div>
+
+      <div className="mb-3">
+        <SearchField
+          onSubmit={handleSearch}
+          onChange={handleSearch}
+          onClear={() => handleSearch('')}
+          value={enrolledSearch}
+          placeholder={intl.formatMessage(messages.searchPlaceholder)}
+        />
+      </div>
+
+      {isLoading && (
+        <div className="d-flex justify-content-center py-4">
+          <Spinner animation="border" screenReaderText={intl.formatMessage(messages.loading)} />
+        </div>
+      )}
+
+      {!isLoading && (!data || data.results.length === 0) && !isFetching && (
+        <p className="text-muted text-center py-4">
+          {enrolledSearch
+            ? intl.formatMessage(messages.noResults)
+            : intl.formatMessage(messages.emptyEnrollment)}
+        </p>
+      )}
+
+      <div style={{ opacity: isFetching && !isLoading ? 0.4 : 1, transition: 'opacity 0.15s' }}>
+        {!isLoading && data?.results.map((learner, index) => (
+          <div
+            key={learner.id}
+            className="d-flex align-items-center py-3"
+            style={{ borderBottom: '1px solid #dee2e6' }}
+          >
+            <span
+              className="mr-3 font-weight-bold text-muted"
+              style={{
+                width: '28px',
+                height: '28px',
+                borderRadius: '50%',
+                background: '#f0f0f0',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+                fontSize: '0.8em',
+              }}
+            >
+              {(enrolledPage - 1) * 5 + index + 1}
+            </span>
+            <div className="flex-grow-1">
+              <p className="mb-0 font-weight-bold">{learner.name}</p>
+              <Stack direction="horizontal" gap={1} className="flex-wrap mt-1">
+                <Badge variant="light">{learner.email}</Badge>
+              </Stack>
+            </div>
+            <Button
+              variant="outline-danger"
+              size="sm"
+              onClick={() => setConfirmUnenrollUsername(learner.username)}
+              disabled={confirmUnenrollUsername !== null}
+            >
+              {intl.formatMessage(messages.unenrollBtn)}
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      {isFetching && !isLoading && (
+        <div className="d-flex justify-content-center py-2">
+          <Spinner animation="border" screenReaderText={intl.formatMessage(messages.loading)} />
+        </div>
+      )}
+
+      {data && data.numPages > 1 && (
+        <Pagination
+          paginationLabel={intl.formatMessage(messages.paginationLabel)}
+          pageCount={data.numPages}
+          currentPage={enrolledPage}
+          onPageSelect={(page: number) => setEnrolledPage(page)}
+          className="mt-3"
+        />
+      )}
+
+      <AddLearnerModal
+        isOpen={isModalOpen}
+        onClose={closeModal}
+        programId={programId}
+        alreadyEnrolledIds={enrolledIds}
+      />
+
+      <EnrollBatchModal
+        isOpen={isBatchModalOpen}
+        onClose={closeBatchModal}
+        programId={programId}
+        alreadyEnrolledIds={enrolledIds}
+      />
+
+      <DeleteModal
+        isOpen={!!confirmUnenrollUsername}
+        close={() => setConfirmUnenrollUsername(null)}
+        title={intl.formatMessage(messages.confirmUnenrollTitle)}
+        description={(
+          <>
+            <strong>{confirmLearner?.name ?? confirmUnenrollUsername}</strong>
+            <br />
+            {intl.formatMessage(messages.confirmUnenrollDesc)}
+            {' '}
+            <strong>{intl.formatMessage(messages.confirmUnenrollWarning)}</strong>
+          </>
+        )}
+        btnLabel={intl.formatMessage(messages.confirmUnenrollBtn)}
+        onDeleteSubmit={async () => {
+          await unenrollLearner.mutateAsync({ programId, username: confirmUnenrollUsername! });
+          setConfirmUnenrollUsername(null);
+        }}
+      />
+    </div>
+  );
+};
+
+export default EnrollmentTab;

--- a/src/programs/index.ts
+++ b/src/programs/index.ts
@@ -1,0 +1,1 @@
+export { default as ProgramDetailPage } from './ProgramDetailPage';

--- a/src/programs/instructors-tab/AddInstructorModal.test.tsx
+++ b/src/programs/instructors-tab/AddInstructorModal.test.tsx
@@ -1,0 +1,104 @@
+import {
+  fireEvent, initializeMocks, render, screen, waitFor,
+} from '@src/testUtils';
+import AddInstructorModal from './AddInstructorModal';
+import { mockInstructor } from '../data/api.mock';
+import type { Instructor } from '../data/types';
+
+const mockAddMutate = jest.fn();
+const mockUseInstructors = jest.fn();
+
+jest.mock('@src/programs/data/apiHooks', () => ({
+  useInstructors: (...args: any[]) => mockUseInstructors(...args),
+  useAddInstructorToCourse: () => ({ mutateAsync: mockAddMutate, isPending: false }),
+}));
+
+// Helper: convert Instructor to the PaginatedLearners shape the hook returns
+const instructorPage = (instructors: Instructor[]) => ({
+  results: instructors.map((i) => ({
+    id: i.username, username: i.username, email: i.email, name: i.name,
+  })),
+  count: instructors.length,
+  numPages: 1,
+});
+
+const defaultProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+  courseId: 'course-v1:Org+X+2025',
+  courseName: 'CS 101',
+  alreadyAddedEmails: [],
+};
+
+describe('<AddInstructorModal />', () => {
+  beforeEach(() => {
+    initializeMocks();
+    mockAddMutate.mockResolvedValue(undefined);
+    mockUseInstructors.mockReturnValue({
+      data: instructorPage([mockInstructor()]),
+      isLoading: false,
+      isFetching: false,
+    });
+  });
+
+  it('renders instructor list when open', () => {
+    render(<AddInstructorModal {...defaultProps} />);
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+    expect(screen.getByText('john@example.com')).toBeInTheDocument();
+  });
+
+  it('shows "Added" badge for already-added instructor', () => {
+    mockUseInstructors.mockReturnValue({
+      data: instructorPage([mockInstructor({ email: 'john@example.com' })]),
+      isLoading: false,
+      isFetching: false,
+    });
+    render(<AddInstructorModal {...defaultProps} alreadyAddedEmails={['john@example.com']} />);
+    expect(screen.getByText('Added')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Add$/i })).not.toBeInTheDocument();
+  });
+
+  it('shows "Add" button for non-added instructor', () => {
+    render(<AddInstructorModal {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /^Add$/i })).toBeInTheDocument();
+  });
+
+  it('calls addInstructor with courseId and email when Add is clicked', async () => {
+    mockUseInstructors.mockReturnValue({
+      data: instructorPage([mockInstructor({ email: 'jane@example.com' })]),
+      isLoading: false,
+      isFetching: false,
+    });
+    render(<AddInstructorModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/i }));
+    await waitFor(() => expect(mockAddMutate).toHaveBeenCalledWith({
+      courseId: 'course-v1:Org+X+2025',
+      email: 'jane@example.com',
+    }));
+  });
+
+  it('shows error alert when mutation rejects', async () => {
+    mockAddMutate.mockRejectedValue(new Error('Network error'));
+    render(<AddInstructorModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/i }));
+    expect(await screen.findByText(/Failed to add instructor/i)).toBeInTheDocument();
+  });
+
+  it('renders pagination when numPages > 1', () => {
+    mockUseInstructors.mockReturnValue({
+      data: { ...instructorPage([mockInstructor()]), numPages: 3 },
+      isLoading: false,
+      isFetching: false,
+    });
+    render(<AddInstructorModal {...defaultProps} />);
+    expect(screen.getByRole('navigation', { name: /Instructor list pagination/i })).toBeInTheDocument();
+  });
+
+  it('passes enabled=false to useInstructors when modal is closed', () => {
+    render(<AddInstructorModal {...defaultProps} isOpen={false} />);
+    expect(mockUseInstructors).toHaveBeenCalledWith(
+      expect.any(Object),
+      false,
+    );
+  });
+});

--- a/src/programs/instructors-tab/AddInstructorModal.tsx
+++ b/src/programs/instructors-tab/AddInstructorModal.tsx
@@ -1,0 +1,176 @@
+import React, {
+  useCallback, useEffect, useRef, useState,
+} from 'react';
+import {
+  ActionRow,
+  Alert,
+  Badge,
+  Button,
+  ModalDialog,
+  Pagination,
+  SearchField,
+  Spinner,
+} from '@openedx/paragon';
+import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
+import { useInstructors, useAddInstructorToCourse } from '../data/apiHooks';
+
+const messages = defineMessages({
+  title: { id: 'programs.instructors.modal.title', defaultMessage: 'Add Instructor to Course' },
+  searchPlaceholder: { id: 'programs.instructors.modal.search', defaultMessage: 'Search instructors...' },
+  addBtn: { id: 'programs.instructors.modal.add', defaultMessage: 'Add' },
+  addingBtn: { id: 'programs.instructors.modal.adding', defaultMessage: 'Adding...' },
+  addedBadge: { id: 'programs.instructors.modal.added', defaultMessage: 'Added' },
+  cancelBtn: { id: 'programs.instructors.modal.cancel', defaultMessage: 'Cancel' },
+  noResults: { id: 'programs.instructors.modal.no-results', defaultMessage: 'No instructors match your search.' },
+  loading: { id: 'programs.instructors.modal.loading', defaultMessage: 'Loading instructors...' },
+  addError: { id: 'programs.instructors.modal.add-error', defaultMessage: 'Failed to add instructor. Please try again.' },
+  paginationLabel: { id: 'programs.instructors.modal.pagination', defaultMessage: 'Instructor list pagination' },
+});
+
+interface AddInstructorModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  courseId: string;
+  courseName: string;
+  alreadyAddedEmails: string[];
+}
+
+const AddInstructorModal: React.FC<AddInstructorModalProps> = ({
+  isOpen, onClose, courseId, courseName, alreadyAddedEmails,
+}) => {
+  const intl = useIntl();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [addingId, setAddingId] = useState<string | null>(null);
+  const [addError, setAddError] = useState(false);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const { data, isLoading, isFetching } = useInstructors(
+    { page: currentPage, search: searchQuery },
+    isOpen,
+  );
+  const { mutateAsync: addInstructor } = useAddInstructorToCourse();
+
+  useEffect(() => {
+    listRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [currentPage]);
+
+  const handleSearch = useCallback((q: string) => {
+    setSearchQuery(q);
+    setCurrentPage(1);
+  }, []);
+
+  const handleAdd = async (email: string) => {
+    setAddingId(email);
+    setAddError(false);
+    try {
+      await addInstructor({ courseId, email });
+    } catch {
+      setAddError(true);
+    } finally {
+      setAddingId(null);
+    }
+  };
+
+  const handleClose = () => {
+    setSearchQuery('');
+    setCurrentPage(1);
+    setAddError(false);
+    onClose();
+  };
+
+  return (
+    <ModalDialog
+      title={intl.formatMessage(messages.title)}
+      isOpen={isOpen}
+      onClose={handleClose}
+      size="lg"
+      hasCloseButton
+      isFullscreenOnMobile
+      isOverflowVisible={false}
+    >
+      <ModalDialog.Header style={{ zIndex: 9 }}>
+        <ModalDialog.Title>{intl.formatMessage(messages.title)}</ModalDialog.Title>
+        <p className="small text-muted mt-1 mb-3">{courseName}</p>
+        <SearchField
+          onSubmit={handleSearch}
+          onChange={handleSearch}
+          onClear={() => handleSearch('')}
+          value={searchQuery}
+          placeholder={intl.formatMessage(messages.searchPlaceholder)}
+        />
+      </ModalDialog.Header>
+
+      <ModalDialog.Body>
+        {addError && (
+          <Alert variant="danger" className="mb-3">
+            {intl.formatMessage(messages.addError)}
+          </Alert>
+        )}
+        {isLoading && (
+          <div className="d-flex justify-content-center py-4">
+            <Spinner animation="border" screenReaderText={intl.formatMessage(messages.loading)} />
+          </div>
+        )}
+        {!isLoading && (!data || data.results.length === 0) && !isFetching && (
+          <p className="text-muted text-center py-4">{intl.formatMessage(messages.noResults)}</p>
+        )}
+        <div ref={listRef} />
+        <div style={{ opacity: isFetching && !isLoading ? 0.4 : 1, transition: 'opacity 0.15s' }}>
+          {!isLoading && data?.results.map((instructor) => {
+            const isAdded = alreadyAddedEmails.includes(instructor.email);
+            const isAdding = addingId === instructor.email;
+            return (
+              <div
+                key={instructor.id}
+                className="d-flex justify-content-between align-items-center py-3"
+                style={{ borderBottom: '1px solid #dee2e6' }}
+              >
+                <div>
+                  <p className="mb-1 font-weight-bold">{instructor.name}</p>
+                  <p className="mb-0 small text-muted">{instructor.email}</p>
+                </div>
+                {isAdded ? (
+                  <Badge variant="success">{intl.formatMessage(messages.addedBadge)}</Badge>
+                ) : (
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() => handleAdd(instructor.email)}
+                    disabled={isAdding || !!addingId}
+                  >
+                    {isAdding ? intl.formatMessage(messages.addingBtn) : intl.formatMessage(messages.addBtn)}
+                  </Button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+        {isFetching && !isLoading && (
+          <div className="d-flex justify-content-center py-2">
+            <Spinner animation="border" screenReaderText={intl.formatMessage(messages.loading)} />
+          </div>
+        )}
+        {data && data.numPages > 1 && (
+          <Pagination
+            paginationLabel={intl.formatMessage(messages.paginationLabel)}
+            pageCount={data.numPages}
+            currentPage={currentPage}
+            onPageSelect={(page: number) => setCurrentPage(page)}
+            className="mt-3"
+          />
+        )}
+      </ModalDialog.Body>
+
+      <ModalDialog.Footer>
+        <ActionRow>
+          <ModalDialog.CloseButton variant="tertiary">
+            {intl.formatMessage(messages.cancelBtn)}
+          </ModalDialog.CloseButton>
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
+  );
+};
+
+export default AddInstructorModal;

--- a/src/programs/instructors-tab/InstructorsTab.test.tsx
+++ b/src/programs/instructors-tab/InstructorsTab.test.tsx
@@ -1,0 +1,92 @@
+import {
+  fireEvent, initializeMocks, render, screen, waitFor,
+} from '@src/testUtils';
+import InstructorsTab from './InstructorsTab';
+import { mockCourse, mockInstructor, mockProgram } from '../data/api.mock';
+
+const mockRemoveMutate = jest.fn();
+const mockUseCourseTeam = jest.fn();
+
+jest.mock('@src/programs/data/apiHooks', () => ({
+  useCourseTeam: (...args: any[]) => mockUseCourseTeam(...args),
+  useRemoveInstructorFromCourse: () => ({ mutateAsync: mockRemoveMutate, isPending: false }),
+  // AddInstructorModal is rendered as a child; supply stubs so it doesn't throw
+  useInstructors: () => ({ data: { results: [], count: 0, numPages: 1 }, isLoading: false, isFetching: false }),
+  useAddInstructorToCourse: () => ({ mutateAsync: jest.fn(), isPending: false }),
+}));
+
+describe('<InstructorsTab />', () => {
+  beforeEach(() => {
+    initializeMocks();
+    mockRemoveMutate.mockResolvedValue(undefined);
+    mockUseCourseTeam.mockReturnValue({ data: [], isLoading: false });
+  });
+
+  it('shows "no courses" alert when program has no courses', () => {
+    const program = mockProgram({ courses: [] });
+    render(<InstructorsTab program={program} />);
+    expect(screen.getByText(/No courses added to this program/i)).toBeInTheDocument();
+  });
+
+  it('shows course dropdown when program has courses', () => {
+    const course = mockCourse({ displayName: 'CS 101' });
+    const program = mockProgram({ courses: [course] });
+    render(<InstructorsTab program={program} />);
+    expect(screen.getByRole('option', { name: 'CS 101' })).toBeInTheDocument();
+  });
+
+  it('"Add Instructor" is disabled when no course selected', () => {
+    const program = mockProgram({ courses: [mockCourse()] });
+    render(<InstructorsTab program={program} />);
+    expect(screen.getByRole('button', { name: /Add Instructor/i })).toBeDisabled();
+  });
+
+  it('shows instructor list after selecting a course', async () => {
+    const course = mockCourse({ id: 'course-v1:Org+X+2025', displayName: 'CS 101' });
+    const instructor = mockInstructor({ name: 'Prof. Smith', email: 'smith@example.com' });
+    mockUseCourseTeam.mockReturnValue({ data: [instructor], isLoading: false });
+    const program = mockProgram({ courses: [course] });
+    render(<InstructorsTab program={program} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'course-v1:Org+X+2025' } });
+    expect(await screen.findByText('Prof. Smith')).toBeInTheDocument();
+    expect(screen.getByText('smith@example.com')).toBeInTheDocument();
+  });
+
+  it('shows role badge for instructor', async () => {
+    const course = mockCourse({ id: 'course-v1:Org+X+2025', displayName: 'CS 101' });
+    const instructor = mockInstructor({ role: 'staff' });
+    mockUseCourseTeam.mockReturnValue({ data: [instructor], isLoading: false });
+    const program = mockProgram({ courses: [course] });
+    render(<InstructorsTab program={program} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'course-v1:Org+X+2025' } });
+    expect(await screen.findByText('staff')).toBeInTheDocument();
+  });
+
+  it('opens confirmation dialog when Remove is clicked', async () => {
+    const course = mockCourse({ id: 'course-v1:Org+X+2025', displayName: 'CS 101' });
+    const instructor = mockInstructor({ email: 'smith@example.com' });
+    mockUseCourseTeam.mockReturnValue({ data: [instructor], isLoading: false });
+    const program = mockProgram({ courses: [course] });
+    render(<InstructorsTab program={program} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'course-v1:Org+X+2025' } });
+    fireEvent.click(await screen.findByRole('button', { name: /^Remove$/ }));
+    expect(screen.getByText('Remove Instructor?')).toBeInTheDocument();
+    // Email appears in both the row badge and the dialog description
+    expect(screen.getAllByText('smith@example.com').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('calls removeInstructor with courseId and email when confirm is clicked', async () => {
+    const course = mockCourse({ id: 'course-v1:Org+X+2025', displayName: 'CS 101' });
+    const instructor = mockInstructor({ email: 'smith@example.com' });
+    mockUseCourseTeam.mockReturnValue({ data: [instructor], isLoading: false });
+    const program = mockProgram({ courses: [course] });
+    render(<InstructorsTab program={program} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'course-v1:Org+X+2025' } });
+    fireEvent.click(await screen.findByRole('button', { name: /Remove/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Remove Instructor/i }));
+    await waitFor(() => expect(mockRemoveMutate).toHaveBeenCalledWith({
+      courseId: 'course-v1:Org+X+2025',
+      email: 'smith@example.com',
+    }));
+  });
+});

--- a/src/programs/instructors-tab/InstructorsTab.tsx
+++ b/src/programs/instructors-tab/InstructorsTab.tsx
@@ -1,0 +1,183 @@
+import React, { useState, useCallback } from 'react';
+import {
+  Alert,
+  Badge,
+  Button,
+  Form,
+  Spinner,
+  Stack,
+  useToggle,
+} from '@openedx/paragon';
+import { Add } from '@openedx/paragon/icons';
+import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
+import type { Program } from '../data/types';
+import { useCourseTeam, useRemoveInstructorFromCourse } from '../data/apiHooks';
+import DeleteModal from '../../generic/delete-modal/DeleteModal';
+import AddInstructorModal from './AddInstructorModal';
+
+const messages = defineMessages({
+  sectionTitle: { id: 'programs.instructors.title', defaultMessage: 'Course Instructors' },
+  sectionSubtitle: { id: 'programs.instructors.subtitle', defaultMessage: 'Assign instructors to courses within this program' },
+  addInstructorBtn: { id: 'programs.instructors.add-btn', defaultMessage: 'Add Instructor' },
+  courseSelectLabel: { id: 'programs.instructors.course-select.label', defaultMessage: 'Select a Course' },
+  courseSelectPlaceholder: { id: 'programs.instructors.course-select.placeholder', defaultMessage: '-- Select a course to manage instructors --' },
+  noCoursesMsg: { id: 'programs.instructors.no-courses', defaultMessage: 'No courses added to this program yet. Add courses in the Courses tab first.' },
+  selectCoursePrompt: { id: 'programs.instructors.select-course-prompt', defaultMessage: 'Select a course above to view and assign instructors.' },
+  loading: { id: 'programs.instructors.loading', defaultMessage: 'Loading team...' },
+  emptyTeam: { id: 'programs.instructors.empty-team', defaultMessage: 'No instructors assigned yet. Click \'+ Add Instructor\' to begin.' },
+  removeBtn: { id: 'programs.instructors.remove-btn', defaultMessage: 'Remove' },
+  confirmRemoveTitle: { id: 'programs.instructors.confirm-remove.title', defaultMessage: 'Remove Instructor?' },
+  confirmRemoveDesc: { id: 'programs.instructors.confirm-remove.desc', defaultMessage: 'This instructor will be removed from the course team. They will lose access to the course.' },
+  confirmRemoveBtn: { id: 'programs.instructors.confirm-remove.btn', defaultMessage: 'Remove Instructor' },
+});
+
+interface InstructorsTabProps {
+  program: Program;
+}
+
+const InstructorsTab: React.FC<InstructorsTabProps> = ({ program }) => {
+  const intl = useIntl();
+  const courses = program.courses ?? [];
+
+  const [selectedCourseId, setSelectedCourseId] = useState('');
+  const [confirmEmail, setConfirmEmail] = useState<string | null>(null);
+  const [isModalOpen, openModal, closeModal] = useToggle(false);
+
+  const { data: team, isLoading: isTeamLoading } = useCourseTeam(selectedCourseId, !!selectedCourseId);
+  const removeInstructor = useRemoveInstructorFromCourse();
+
+  const teamEmails = team?.map((i) => i.email) ?? [];
+  const selectedCourse = courses.find((c) => c.id === selectedCourseId);
+
+  const handleCourseChange = useCallback((courseId: string) => {
+    setSelectedCourseId(courseId);
+  }, []);
+
+  return (
+    <div className="mt-4">
+      <div className="d-flex justify-content-between align-items-start mb-4">
+        <div>
+          <h3 className="mb-1">{intl.formatMessage(messages.sectionTitle)}</h3>
+          <p className="text-muted small mb-0">{intl.formatMessage(messages.sectionSubtitle)}</p>
+        </div>
+        <Button
+          variant="outline-primary"
+          iconBefore={Add}
+          size="sm"
+          onClick={openModal}
+          disabled={!selectedCourseId}
+        >
+          {intl.formatMessage(messages.addInstructorBtn)}
+        </Button>
+      </div>
+
+      {courses.length === 0 ? (
+        <Alert variant="info">{intl.formatMessage(messages.noCoursesMsg)}</Alert>
+      ) : (
+        <Form.Group className="mb-4" style={{ maxWidth: '480px' }}>
+          <Form.Label>{intl.formatMessage(messages.courseSelectLabel)}</Form.Label>
+          <Form.Control
+            as="select"
+            value={selectedCourseId}
+            onChange={(e) => handleCourseChange((e as any).target.value)}
+          >
+            <option value="">{intl.formatMessage(messages.courseSelectPlaceholder)}</option>
+            {courses.map((c) => (
+              <option key={c.id} value={c.id}>{c.displayName}</option>
+            ))}
+          </Form.Control>
+        </Form.Group>
+      )}
+
+      {!selectedCourseId && courses.length > 0 && (
+        <p className="text-muted">{intl.formatMessage(messages.selectCoursePrompt)}</p>
+      )}
+
+      {selectedCourseId && (
+        <>
+          {isTeamLoading && (
+            <div className="d-flex justify-content-center py-4">
+              <Spinner animation="border" screenReaderText={intl.formatMessage(messages.loading)} />
+            </div>
+          )}
+
+          {!isTeamLoading && team?.length === 0 && (
+            <p className="text-muted">{intl.formatMessage(messages.emptyTeam)}</p>
+          )}
+
+          {!isTeamLoading && team && team.length > 0 && (
+            <div>
+              {team.map((instructor, index) => (
+                <div
+                  key={instructor.id}
+                  className="d-flex align-items-center py-3"
+                  style={{ borderBottom: '1px solid #dee2e6' }}
+                >
+                  <span
+                    className="mr-3 font-weight-bold text-muted"
+                    style={{
+                      width: '28px',
+                      height: '28px',
+                      borderRadius: '50%',
+                      background: '#f0f0f0',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      flexShrink: 0,
+                      fontSize: '0.8em',
+                    }}
+                  >
+                    {index + 1}
+                  </span>
+                  <div className="flex-grow-1">
+                    <p className="mb-0 font-weight-bold">{instructor.name}</p>
+                    <Stack direction="horizontal" gap={1} className="flex-wrap mt-1">
+                      <Badge variant="light">{instructor.email}</Badge>
+                      {instructor.role && <Badge variant="secondary">{instructor.role}</Badge>}
+                    </Stack>
+                  </div>
+                  <Button
+                    variant="outline-danger"
+                    size="sm"
+                    onClick={() => setConfirmEmail(instructor.email)}
+                    disabled={confirmEmail !== null}
+                  >
+                    {intl.formatMessage(messages.removeBtn)}
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      <AddInstructorModal
+        isOpen={isModalOpen}
+        onClose={closeModal}
+        courseId={selectedCourseId}
+        courseName={selectedCourse?.displayName ?? ''}
+        alreadyAddedEmails={teamEmails}
+      />
+
+      <DeleteModal
+        isOpen={!!confirmEmail}
+        close={() => setConfirmEmail(null)}
+        title={intl.formatMessage(messages.confirmRemoveTitle)}
+        description={(
+          <>
+            <strong>{confirmEmail}</strong>
+            <br />
+            {intl.formatMessage(messages.confirmRemoveDesc)}
+          </>
+        )}
+        btnLabel={intl.formatMessage(messages.confirmRemoveBtn)}
+        onDeleteSubmit={async () => {
+          await removeInstructor.mutateAsync({ courseId: selectedCourseId, email: confirmEmail! });
+          setConfirmEmail(null);
+        }}
+      />
+    </div>
+  );
+};
+
+export default InstructorsTab;

--- a/src/schedule-and-details/index.jsx
+++ b/src/schedule-and-details/index.jsx
@@ -40,6 +40,7 @@ import LearningOutcomesSection from './learning-outcomes-section';
 import InstructorsSection from './instructors-section';
 import RequirementsSection from './requirements-section';
 import LicenseSection from './license-section';
+import TargetAudienceSection from './target-audience-section';
 import ScheduleSidebar from './schedule-sidebar';
 import messages from './messages';
 import { useLoadValuesPrompt, useSaveValuesPrompt } from './hooks';
@@ -279,6 +280,7 @@ const ScheduleAndDetails = ({ courseId }) => {
                       onChange={handleValuesChange}
                     />
                   )}
+                  <TargetAudienceSection courseId={courseId} />
                   <IntroducingSection
                     title={title}
                     overview={initialOverview}

--- a/src/schedule-and-details/target-audience-section/index.jsx
+++ b/src/schedule-and-details/target-audience-section/index.jsx
@@ -1,0 +1,177 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import {
+  ActionRow,
+  Alert,
+  Button,
+  Form,
+  Spinner,
+  TransitionReplace,
+} from '@openedx/paragon';
+import {
+  CheckCircle as CheckCircleIcon,
+  ErrorOutline as ErrorOutlineIcon,
+} from '@openedx/paragon/icons';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import CreatableSelectBase from 'react-select/creatable';
+import SectionSubHeader from '../../generic/section-sub-header';
+import {
+  useTargetAudiences,
+  useCourseTargetAudience,
+  useUpdateCourseTargetAudience,
+} from '../../programs/data/apiHooks';
+import messages from './messages';
+
+// ContentTagsCollapsible.d.ts globally augments react-select/base Props — cast required
+const CreatableSelect = CreatableSelectBase;
+
+const formatAudienceCreateLabel = (inputValue) => (
+  <span>
+    <strong style={{ color: '#0a58ca' }}>+ Add new audience type: </strong>
+    <em>&ldquo;{inputValue}&rdquo;</em>
+  </span>
+);
+
+const TargetAudienceSection = ({ courseId }) => {
+  const intl = useIntl();
+
+  const { data: audiences } = useTargetAudiences();
+  const { data: courseData, isLoading } = useCourseTargetAudience(courseId);
+  const { mutateAsync: updateAudience, isPending: isSaving } = useUpdateCourseTargetAudience();
+
+  const savedAudience = courseData?.targetAudience ?? '';
+  // null = not yet initialised from server; avoids a spurious isDirty flash
+  // on the render between data arriving and the sync effect running.
+  const [localAudience, setLocalAudience] = useState(null);
+  const [showSuccess, setShowSuccess] = useState(false);
+  const [showError, setShowError] = useState(false);
+
+  // Sync local state when the saved value loads/changes
+  useEffect(() => {
+    setLocalAudience(savedAudience);
+  }, [savedAudience]);
+
+  const isDirty = localAudience !== null && localAudience !== savedAudience;
+
+  const audienceOptions = (audiences ?? []).map((name) => ({ value: name, label: name }));
+  const selectedOption = localAudience ? { value: localAudience, label: localAudience } : null;
+
+  const handleSave = async () => {
+    setShowSuccess(false);
+    setShowError(false);
+    try {
+      await updateAudience({ courseKey: courseId, audienceName: localAudience || null });
+      setShowSuccess(true);
+      setTimeout(() => setShowSuccess(false), 5000);
+    } catch {
+      setShowError(true);
+    }
+  };
+
+  const handleCancel = () => {
+    setLocalAudience(savedAudience);
+    setShowSuccess(false);
+    setShowError(false);
+  };
+
+  return (
+    <section className="section-container target-audience-section">
+      <SectionSubHeader
+        title={intl.formatMessage(messages.sectionTitle)}
+        description={intl.formatMessage(messages.sectionDescription)}
+      />
+
+      <TransitionReplace>
+        {showSuccess ? (
+          <Alert
+            key="success"
+            variant="success"
+            icon={CheckCircleIcon}
+            dismissible
+            onClose={() => setShowSuccess(false)}
+            className="mb-3"
+          >
+            {intl.formatMessage(messages.savedSuccess)}
+          </Alert>
+        ) : null}
+      </TransitionReplace>
+      <TransitionReplace>
+        {showError ? (
+          <Alert
+            key="error"
+            variant="danger"
+            icon={ErrorOutlineIcon}
+            dismissible
+            onClose={() => setShowError(false)}
+            className="mb-3"
+          >
+            {intl.formatMessage(messages.savedError)}
+          </Alert>
+        ) : null}
+      </TransitionReplace>
+
+      {isLoading ? (
+        <Spinner animation="border" size="sm" className="ml-2" />
+      ) : (
+        <Form.Group className="form-group-custom">
+          <Form.Label>{intl.formatMessage(messages.fieldLabel)}</Form.Label>
+          <CreatableSelect
+            isClearable
+            options={audienceOptions}
+            value={selectedOption}
+            onChange={(option) => setLocalAudience(option?.value ?? '')}
+            onCreateOption={(inputValue) => setLocalAudience(inputValue)}
+            isValidNewOption={(inputValue) => {
+              if (!inputValue.trim()) { return false; }
+              const normalized = inputValue.toLowerCase();
+              return !audienceOptions.some((o) => o.value.toLowerCase() === normalized);
+            }}
+            formatCreateLabel={formatAudienceCreateLabel}
+            placeholder={intl.formatMessage(messages.fieldPlaceholder)}
+            styles={{
+              control: (base, state) => ({
+                ...base,
+                minHeight: '38px',
+                borderColor: state.isFocused ? '#0d6efd' : '#adb5bd',
+                boxShadow: state.isFocused ? '0 0 0 1px #0d6efd' : 'none',
+                '&:hover': { borderColor: '#0d6efd' },
+              }),
+              menu: (base) => ({ ...base, zIndex: 9999 }),
+            }}
+          />
+          <Form.Text muted>{intl.formatMessage(messages.fieldHint)}</Form.Text>
+
+          {isDirty && (
+            <ActionRow className="mt-3">
+              <Button
+                variant="tertiary"
+                size="sm"
+                onClick={handleCancel}
+                disabled={isSaving}
+              >
+                {intl.formatMessage(messages.cancelBtn)}
+              </Button>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleSave}
+                disabled={isSaving}
+              >
+                {isSaving ? (
+                  <Spinner animation="border" size="sm" className="mr-1" />
+                ) : null}
+                {intl.formatMessage(messages.saveBtn)}
+              </Button>
+            </ActionRow>
+          )}
+        </Form.Group>
+      )}
+    </section>
+  );
+};
+
+TargetAudienceSection.propTypes = {
+  courseId: PropTypes.string.isRequired,
+};
+
+export default TargetAudienceSection;

--- a/src/schedule-and-details/target-audience-section/messages.js
+++ b/src/schedule-and-details/target-audience-section/messages.js
@@ -1,0 +1,46 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  sectionTitle: {
+    id: 'course-authoring.schedule-section.target-audience.title',
+    defaultMessage: 'Target Audience',
+  },
+  sectionDescription: {
+    id: 'course-authoring.schedule-section.target-audience.description',
+    defaultMessage: 'The audience this course is designed for.',
+  },
+  fieldLabel: {
+    id: 'course-authoring.schedule-section.target-audience.label',
+    defaultMessage: 'Target audience',
+  },
+  fieldHint: {
+    id: 'course-authoring.schedule-section.target-audience.hint',
+    defaultMessage: 'Select an existing audience type or create a new one.',
+  },
+  fieldPlaceholder: {
+    id: 'course-authoring.schedule-section.target-audience.placeholder',
+    defaultMessage: 'Select or add audience type...',
+  },
+  saveBtn: {
+    id: 'course-authoring.schedule-section.target-audience.save',
+    defaultMessage: 'Save',
+  },
+  cancelBtn: {
+    id: 'course-authoring.schedule-section.target-audience.cancel',
+    defaultMessage: 'Cancel',
+  },
+  savedSuccess: {
+    id: 'course-authoring.schedule-section.target-audience.success',
+    defaultMessage: 'Target audience saved.',
+  },
+  savedError: {
+    id: 'course-authoring.schedule-section.target-audience.error',
+    defaultMessage: 'Failed to save target audience. Please try again.',
+  },
+  audienceAdd: {
+    id: 'course-authoring.schedule-section.target-audience.add',
+    defaultMessage: 'Add "{value}"',
+  },
+});
+
+export default messages;

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -68,5 +68,8 @@ class ResizeObserver {
 
 window.ResizeObserver = ResizeObserver;
 
+// scrollIntoView is not implemented in JSDOM
+Element.prototype.scrollIntoView = jest.fn();
+
 // Mock the plugins repo so jest will stop complaining about ES6 syntax
 jest.mock('frontend-components-tinymce-advanced-plugins', () => {});

--- a/src/studio-home/StudioHome.tsx
+++ b/src/studio-home/StudioHome.tsx
@@ -21,6 +21,7 @@ import TabsSection from './tabs-section';
 import OrganizationSection from './organization-section';
 import VerifyEmailLayout from './verify-email-layout';
 import CreateNewCourseForm from './create-new-course-form';
+import CreateNewProgramForm from './create-new-program-form';
 import messages from './messages';
 import { useStudioHome } from './hooks';
 import AlertMessage from '../generic/alert-message';
@@ -39,10 +40,12 @@ const StudioHome = () => {
     isShowEmailStaff,
     anyQueryIsPending,
     showNewCourseContainer,
+    showNewProgramContainer,
     isShowOrganizationDropdown,
     hasAbilityToCreateNewCourse,
     isFiltered,
     setShowNewCourseContainer,
+    setShowNewProgramContainer,
     librariesV1Enabled,
     librariesV2Enabled,
   } = useStudioHome();
@@ -70,6 +73,18 @@ const StudioHome = () => {
         <MailtoLink to={studioRequestEmail}>{intl.formatMessage(messages.emailStaffBtnText)}</MailtoLink>,
       );
     }
+
+    headerButtons.push(
+      <Button
+        variant="outline-primary"
+        iconBefore={AddIcon}
+        size="sm"
+        disabled={showNewProgramContainer}
+        onClick={() => setShowNewProgramContainer(true)}
+      >
+        {intl.formatMessage(messages.addNewProgramBtnText)}
+      </Button>,
+    );
 
     if (hasAbilityToCreateNewCourse) {
       headerButtons.push(
@@ -144,6 +159,9 @@ const StudioHome = () => {
             {showNewCourseContainer && (
               <CreateNewCourseForm handleOnClickCancel={() => setShowNewCourseContainer(false)} />
             )}
+            {showNewProgramContainer && (
+              <CreateNewProgramForm handleOnClickCancel={() => setShowNewProgramContainer(false)} />
+            )}
             {isShowOrganizationDropdown && <OrganizationSection />}
             <TabsSection
               showNewCourseContainer={showNewCourseContainer}
@@ -151,6 +169,7 @@ const StudioHome = () => {
               isShowProcessing={Boolean(isShowProcessing) && !isFiltered}
               librariesV1Enabled={librariesV1Enabled}
               librariesV2Enabled={librariesV2Enabled}
+              showNewProgramContainer={showNewProgramContainer}
             />
           </section>
         </Layout.Element>

--- a/src/studio-home/create-new-course-form/index.jsx
+++ b/src/studio-home/create-new-course-form/index.jsx
@@ -1,26 +1,80 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
+import { Form } from '@openedx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
+import CreatableSelectBase from 'react-select/creatable';
 
 import { CreateOrRerunCourseForm } from '../../generic/create-or-rerun-course';
+import { useTargetAudiences, useUpdateCourseTargetAudience } from '../../programs/data/apiHooks';
 import messages from './messages';
+
+// ContentTagsCollapsible.d.ts globally augments react-select/base Props — cast required
+const CreatableSelect = CreatableSelectBase;
+
+const formatAudienceCreateLabel = (inputValue) => (
+  <span>
+    <strong style={{ color: '#0a58ca' }}>+ Add new audience type: </strong>
+    <em>&ldquo;{inputValue}&rdquo;</em>
+  </span>
+);
 
 const CreateNewCourseForm = ({ handleOnClickCancel }) => {
   const intl = useIntl();
-  const initialNewCourseData = {
-    displayName: '',
-    org: '',
-    number: '',
-    run: '',
-  };
+  const [selectedAudience, setSelectedAudience] = useState(null);
+
+  const { data: audiences } = useTargetAudiences();
+  const { mutateAsync: updateAudience } = useUpdateCourseTargetAudience();
+
+  const audienceOptions = (audiences ?? []).map((name) => ({ value: name, label: name }));
+
+  const handleAfterCreate = useCallback(async (courseKey) => {
+    if (selectedAudience) {
+      await updateAudience({ courseKey, audienceName: selectedAudience });
+    }
+  }, [selectedAudience, updateAudience]);
+
+  const audienceField = (
+    <Form.Group className="form-group-custom">
+      <Form.Label>{intl.formatMessage(messages.targetAudienceLabel)}</Form.Label>
+      <CreatableSelect
+        isClearable
+        options={audienceOptions}
+        value={selectedAudience ? { value: selectedAudience, label: selectedAudience } : null}
+        onChange={(option) => setSelectedAudience(option?.value ?? null)}
+        onCreateOption={(inputValue) => setSelectedAudience(inputValue)}
+        isValidNewOption={(inputValue) => {
+          if (!inputValue.trim()) { return false; }
+          const normalized = inputValue.toLowerCase();
+          return !audienceOptions.some((o) => o.value.toLowerCase() === normalized);
+        }}
+        formatCreateLabel={formatAudienceCreateLabel}
+        placeholder={intl.formatMessage(messages.targetAudiencePlaceholder)}
+        styles={{
+          control: (base, state) => ({
+            ...base,
+            minHeight: '38px',
+            borderColor: state.isFocused ? '#0d6efd' : '#adb5bd',
+            boxShadow: state.isFocused ? '0 0 0 1px #0d6efd' : 'none',
+            '&:hover': { borderColor: '#0d6efd' },
+          }),
+          menu: (base) => ({ ...base, zIndex: 9999 }),
+        }}
+      />
+      <Form.Text muted>{intl.formatMessage(messages.targetAudienceHint)}</Form.Text>
+    </Form.Group>
+  );
 
   return (
     <div className="mb-4.5" data-testid="create-course-form">
       <CreateOrRerunCourseForm
         title={intl.formatMessage(messages.createNewCourse)}
-        initialValues={initialNewCourseData}
+        initialValues={{
+          displayName: '', org: '', number: '', run: '',
+        }}
         onClickCancel={handleOnClickCancel}
         isCreateNewCourse
+        onAfterCreate={handleAfterCreate}
+        extraFields={audienceField}
       />
     </div>
   );

--- a/src/studio-home/create-new-course-form/messages.js
+++ b/src/studio-home/create-new-course-form/messages.js
@@ -5,6 +5,22 @@ const messages = defineMessages({
     id: 'course-authoring.studio-home.new-course.title',
     defaultMessage: 'Create a new course',
   },
+  targetAudienceLabel: {
+    id: 'course-authoring.studio-home.new-course.target-audience.label',
+    defaultMessage: 'Target Audience',
+  },
+  targetAudiencePlaceholder: {
+    id: 'course-authoring.studio-home.new-course.target-audience.placeholder',
+    defaultMessage: 'Select or add audience type...',
+  },
+  targetAudienceHint: {
+    id: 'course-authoring.studio-home.new-course.target-audience.hint',
+    defaultMessage: 'Optional. Choose an existing type or type a new one to create it.',
+  },
+  targetAudienceAdd: {
+    id: 'course-authoring.studio-home.new-course.target-audience.add',
+    defaultMessage: 'Add "{value}"',
+  },
 });
 
 export default messages;

--- a/src/studio-home/create-new-program-form/index.jsx
+++ b/src/studio-home/create-new-program-form/index.jsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Formik } from 'formik';
+import * as Yup from 'yup';
+import {
+  Alert,
+  Button,
+  Form,
+  StatefulButton,
+} from '@openedx/paragon';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { useNavigate } from 'react-router-dom';
+import { useProgramsConfig, useCreateProgram } from '../../programs/data/apiHooks';
+import messages from './messages';
+
+const CreateNewProgramForm = ({ handleOnClickCancel }) => {
+  const intl = useIntl();
+  const navigate = useNavigate();
+  const { data: config } = useProgramsConfig();
+  const { mutateAsync: createProgram, isPending } = useCreateProgram();
+
+  const orgs = config?.orgs ?? [];
+  const programTypes = config?.programTypes ?? [];
+
+  const validationSchema = Yup.object({
+    displayName: Yup.string().trim().required(intl.formatMessage(messages.programNameRequired)),
+    org: Yup.string().required(intl.formatMessage(messages.orgRequired)),
+    programType: Yup.string().required(intl.formatMessage(messages.programTypeRequired)),
+    run: Yup.string().trim().required(intl.formatMessage(messages.programRunRequired)),
+  });
+
+  const handleSubmit = async (values, { setStatus }) => {
+    try {
+      const created = await createProgram({
+        ...values, targetAudience: '', status: 'draft', isFeatured: false,
+      });
+      navigate(`/programs/${created.id}`);
+    } catch (e) {
+      setStatus({ error: e.message || 'Failed to create program.' });
+    }
+  };
+
+  return (
+    <div className="mb-4" data-testid="create-program-form">
+      <h3 className="mb-3">{intl.formatMessage(messages.createNewProgram)}</h3>
+
+      <Alert variant="warning" className="mb-4">
+        <strong>⚠ Please read before creating: </strong>
+        Organization, Program Type, and Program Run are used to build the program&apos;s unique identifier
+        and <strong>cannot be changed after creation</strong>. Make sure to input them correctly.
+      </Alert>
+
+      <Formik
+        initialValues={{
+          displayName: '',
+          org: '',
+          programType: '',
+          run: '',
+        }}
+        validationSchema={validationSchema}
+        onSubmit={handleSubmit}
+      >
+        {({
+          values,
+          errors,
+          touched,
+          handleChange,
+          handleBlur,
+          handleSubmit: formikSubmit,
+          status,
+        }) => (
+          <Form onSubmit={formikSubmit}>
+            {status?.error && (
+              <Alert variant="danger" className="mb-3">{status.error}</Alert>
+            )}
+
+            {/* Program Name */}
+            <Form.Group isInvalid={touched.displayName && !!errors.displayName}>
+              <Form.Label>{intl.formatMessage(messages.programNameLabel)}</Form.Label>
+              <Form.Control
+                name="displayName"
+                placeholder={intl.formatMessage(messages.programNamePlaceholder)}
+                value={values.displayName}
+                onChange={handleChange}
+                onBlur={handleBlur}
+              />
+              {touched.displayName && errors.displayName && (
+                <Form.Control.Feedback type="invalid">{errors.displayName}</Form.Control.Feedback>
+              )}
+            </Form.Group>
+
+            {/* Organization — non-editable after creation */}
+            <Form.Group isInvalid={touched.org && !!errors.org}>
+              <Form.Label>
+                {intl.formatMessage(messages.orgLabel)}
+                <span className="text-muted small ml-1">(non-editable after creation)</span>
+              </Form.Label>
+              <Form.Control
+                as="select"
+                name="org"
+                value={values.org}
+                onChange={handleChange}
+                onBlur={handleBlur}
+              >
+                <option value="">{intl.formatMessage(messages.selectPlaceholder)}</option>
+                {orgs.map((o) => <option key={o.shortName} value={o.shortName}>{o.name}</option>)}
+              </Form.Control>
+              {touched.org && errors.org && (
+                <Form.Control.Feedback type="invalid">{errors.org}</Form.Control.Feedback>
+              )}
+            </Form.Group>
+
+            {/* Program Type — non-editable after creation */}
+            <Form.Group isInvalid={touched.programType && !!errors.programType}>
+              <Form.Label>
+                {intl.formatMessage(messages.programTypeLabel)}
+                <span className="text-muted small ml-1">(non-editable after creation)</span>
+              </Form.Label>
+              <Form.Control
+                as="select"
+                name="programType"
+                value={values.programType}
+                onChange={handleChange}
+                onBlur={handleBlur}
+              >
+                <option value="">{intl.formatMessage(messages.selectPlaceholder)}</option>
+                {programTypes.map((t) => <option key={t.slug} value={t.slug}>{t.name}</option>)}
+              </Form.Control>
+              {touched.programType && errors.programType && (
+                <Form.Control.Feedback type="invalid">{errors.programType}</Form.Control.Feedback>
+              )}
+            </Form.Group>
+
+            {/* Program Run — non-editable after creation */}
+            <Form.Group isInvalid={touched.run && !!errors.run}>
+              <Form.Label>
+                {intl.formatMessage(messages.programRunLabel)}
+                <span className="text-muted small ml-1">(non-editable after creation)</span>
+              </Form.Label>
+              <Form.Control
+                name="run"
+                placeholder={intl.formatMessage(messages.programRunPlaceholder)}
+                value={values.run}
+                onChange={handleChange}
+                onBlur={handleBlur}
+              />
+              {touched.run && errors.run && (
+                <Form.Control.Feedback type="invalid">{errors.run}</Form.Control.Feedback>
+              )}
+            </Form.Group>
+
+            <div className="d-flex justify-content-end gap-2 mt-3">
+              <Button variant="tertiary" onClick={handleOnClickCancel}>
+                {intl.formatMessage(messages.cancelBtn)}
+              </Button>
+              <StatefulButton
+                type="submit"
+                variant="primary"
+                state={isPending ? 'pending' : 'default'}
+                labels={{
+                  default: intl.formatMessage(messages.createBtn),
+                  pending: intl.formatMessage(messages.pendingBtn),
+                }}
+                disabledStates={['pending']}
+              />
+            </div>
+          </Form>
+        )}
+      </Formik>
+    </div>
+  );
+};
+
+CreateNewProgramForm.propTypes = {
+  handleOnClickCancel: PropTypes.func.isRequired,
+};
+
+export default CreateNewProgramForm;

--- a/src/studio-home/create-new-program-form/messages.js
+++ b/src/studio-home/create-new-program-form/messages.js
@@ -1,0 +1,78 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  createNewProgram: {
+    id: 'course-authoring.studio-home.new-program.title',
+    defaultMessage: 'Create a new program',
+  },
+  programNameLabel: {
+    id: 'course-authoring.studio-home.new-program.name.label',
+    defaultMessage: 'Program name',
+  },
+  programNamePlaceholder: {
+    id: 'course-authoring.studio-home.new-program.name.placeholder',
+    defaultMessage: 'e.g. Advanced Tax Assessment Program',
+  },
+  programNameRequired: {
+    id: 'course-authoring.studio-home.new-program.name.required',
+    defaultMessage: 'Program name is required.',
+  },
+  orgLabel: {
+    id: 'course-authoring.studio-home.new-program.org.label',
+    defaultMessage: 'Organization',
+  },
+  orgRequired: {
+    id: 'course-authoring.studio-home.new-program.org.required',
+    defaultMessage: 'Organization is required.',
+  },
+  programTypeLabel: {
+    id: 'course-authoring.studio-home.new-program.type.label',
+    defaultMessage: 'Program type',
+  },
+  programTypeRequired: {
+    id: 'course-authoring.studio-home.new-program.type.required',
+    defaultMessage: 'Program type is required.',
+  },
+  programRunLabel: {
+    id: 'course-authoring.studio-home.new-program.run.label',
+    defaultMessage: 'Program run',
+  },
+  programRunPlaceholder: {
+    id: 'course-authoring.studio-home.new-program.run.placeholder',
+    defaultMessage: 'e.g. 2024-Q1',
+  },
+  programRunRequired: {
+    id: 'course-authoring.studio-home.new-program.run.required',
+    defaultMessage: 'Program run is required.',
+  },
+  targetAudienceLabel: {
+    id: 'course-authoring.studio-home.new-program.audience.label',
+    defaultMessage: 'Target audience',
+  },
+  targetAudienceRequired: {
+    id: 'course-authoring.studio-home.new-program.audience.required',
+    defaultMessage: 'Target audience is required.',
+  },
+  cancelBtn: {
+    id: 'course-authoring.studio-home.new-program.cancel.btn',
+    defaultMessage: 'Cancel',
+  },
+  createBtn: {
+    id: 'course-authoring.studio-home.new-program.create.btn',
+    defaultMessage: 'Create',
+  },
+  pendingBtn: {
+    id: 'course-authoring.studio-home.new-program.pending.btn',
+    defaultMessage: 'Creating...',
+  },
+  selectPlaceholder: {
+    id: 'course-authoring.studio-home.new-program.select.placeholder',
+    defaultMessage: 'Select...',
+  },
+  nonEditableNote: {
+    id: 'course-authoring.studio-home.new-program.non-editable.note',
+    defaultMessage: 'Organization, Program Type, and Program Run are used to build the program\'s unique identifier and <strong>cannot be changed after creation</strong>. Please make sure to input them correctly.',
+  },
+});
+
+export default messages;

--- a/src/studio-home/hooks.tsx
+++ b/src/studio-home/hooks.tsx
@@ -28,6 +28,7 @@ const useStudioHome = () => {
     deleteNotificationSavingStatus,
   } = useSelector(getSavingStatuses);
   const [showNewCourseContainer, setShowNewCourseContainer] = useState(false);
+  const [showNewProgramContainer, setShowNewProgramContainer] = useState(false);
   const isLoadingPage = studioHomeLoadingStatus === RequestStatus.IN_PROGRESS;
   const isFailedLoadingPage = studioHomeLoadingStatus === RequestStatus.FAILED;
 
@@ -104,11 +105,13 @@ const useStudioHome = () => {
     isShowEmailStaff,
     anyQueryIsPending,
     showNewCourseContainer,
+    showNewProgramContainer,
     courseCreatorSavingStatus,
     isShowOrganizationDropdown,
     hasAbilityToCreateNewCourse,
     isFiltered,
     setShowNewCourseContainer,
+    setShowNewProgramContainer,
     librariesV1Enabled,
     librariesV2Enabled,
   };

--- a/src/studio-home/messages.ts
+++ b/src/studio-home/messages.ts
@@ -9,6 +9,10 @@ const messages = defineMessages({
     id: 'course-authoring.studio-home.add-new-course.btn.text',
     defaultMessage: 'New course',
   },
+  addNewProgramBtnText: {
+    id: 'course-authoring.studio-home.add-new-program.btn.text',
+    defaultMessage: 'New program',
+  },
   addNewLibraryBtnText: {
     id: 'course-authoring.studio-home.add-new-library.btn.text',
     defaultMessage: 'New library',

--- a/src/studio-home/tabs-section/index.tsx
+++ b/src/studio-home/tabs-section/index.tsx
@@ -17,6 +17,7 @@ import messages from './messages';
 import { BaseFilterState, Filter, LibrariesList } from './libraries-tab';
 import LibrariesV2List from './libraries-v2-tab/index';
 import CoursesTab from './courses-tab';
+import ProgramsTab from './programs-tab';
 import { WelcomeLibrariesV2Alert } from './libraries-v2-tab/WelcomeLibrariesV2Alert';
 
 const TabsSection = ({
@@ -25,6 +26,7 @@ const TabsSection = ({
   isShowProcessing,
   librariesV1Enabled,
   librariesV2Enabled,
+  showNewProgramContainer,
 }) => {
   const intl = useIntl();
   const navigate = useNavigate();
@@ -32,6 +34,7 @@ const TabsSection = ({
   const [migrationFilter, setMigrationFilter] = useState<Filter[]>(BaseFilterState);
   const TABS_LIST = {
     courses: 'courses',
+    programs: 'programs',
     libraries: 'libraries',
     legacyLibraries: 'legacyLibraries',
     archived: 'archived',
@@ -48,6 +51,10 @@ const TabsSection = ({
       return librariesV2Enabled
         ? TABS_LIST.libraries
         : TABS_LIST.legacyLibraries;
+    }
+
+    if (pname.includes('/programs')) {
+      return TABS_LIST.programs;
     }
 
     // Default to courses tab
@@ -72,6 +79,16 @@ const TabsSection = ({
   // the correct operation of iterating over child elements inside the Paragon Tabs component.
   const visibleTabs = useMemo(() => {
     const tabs: JSX.Element[] = [];
+    tabs.push(
+      <Tab
+        key={TABS_LIST.programs}
+        eventKey={TABS_LIST.programs}
+        title={intl.formatMessage(messages.programsTabTitle)}
+      >
+        <ProgramsTab showNewProgramContainer={showNewProgramContainer} />
+      </Tab>,
+    );
+
     tabs.push(
       <Tab
         key={TABS_LIST.courses}
@@ -141,11 +158,13 @@ const TabsSection = ({
     }
 
     return tabs;
-  }, [showNewCourseContainer, isLoadingCourses, migrationFilter]);
+  }, [showNewCourseContainer, showNewProgramContainer, isLoadingCourses, migrationFilter]);
 
   const handleSelectTab = (tab: TabKeyType) => {
     if (tab === TABS_LIST.courses) {
       navigate('/home');
+    } else if (tab === TABS_LIST.programs) {
+      navigate('/programs');
     } else if (tab === TABS_LIST.legacyLibraries) {
       navigate('/libraries-v1');
     } else if (tab === TABS_LIST.libraries) {
@@ -174,6 +193,7 @@ TabsSection.propTypes = {
   isShowProcessing: PropTypes.bool.isRequired,
   librariesV1Enabled: PropTypes.bool,
   librariesV2Enabled: PropTypes.bool,
+  showNewProgramContainer: PropTypes.bool,
 };
 
 export default TabsSection;

--- a/src/studio-home/tabs-section/messages.ts
+++ b/src/studio-home/tabs-section/messages.ts
@@ -45,6 +45,10 @@ const messages = defineMessages({
     id: 'course-authoring.studio-home.courses.tab.course.not.found.alert.clean.filters.button',
     defaultMessage: 'Clear filters',
   },
+  programsTabTitle: {
+    id: 'course-authoring.studio-home.programs.tab.title',
+    defaultMessage: 'Programs',
+  },
   taxonomiesTabTitle: {
     id: 'course-authoring.studio-home.taxonomies.tab.title',
     defaultMessage: 'Taxonomies',

--- a/src/studio-home/tabs-section/programs-tab/ProgramCard.tsx
+++ b/src/studio-home/tabs-section/programs-tab/ProgramCard.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Card, Icon, Stack } from '@openedx/paragon';
+import { ArrowForward } from '@openedx/paragon/icons';
+import type { Program } from '../../../programs/data/types';
+
+interface Props {
+  program: Program;
+}
+
+const ProgramCard: React.FC<Props> = ({ program }) => {
+  const {
+    id, displayName, org, programType, run,
+  } = program;
+
+  return (
+    <div className="w-100 mb-2">
+      <Card className="card-item">
+        <Card.Header
+          size="sm"
+          title={(
+            <Link to={`/programs/${id}`} className="card-item-title">
+              {displayName || id}
+            </Link>
+          )}
+          subtitle={`${org} / ${programType} / ${run}`}
+          actions={(
+            <Stack direction="horizontal" gap={2} className="align-items-center">
+              <Icon src={ArrowForward} size="sm" />
+            </Stack>
+          )}
+        />
+      </Card>
+    </div>
+  );
+};
+
+export default ProgramCard;

--- a/src/studio-home/tabs-section/programs-tab/index.tsx
+++ b/src/studio-home/tabs-section/programs-tab/index.tsx
@@ -1,0 +1,132 @@
+import React, { useState, useMemo } from 'react';
+import {
+  Dropdown,
+  Icon,
+  Row,
+  SearchField,
+} from '@openedx/paragon';
+import { Check } from '@openedx/paragon/icons';
+import { useIntl, defineMessages } from '@edx/frontend-platform/i18n';
+import { LoadingSpinner } from '@src/generic/Loading';
+import { usePrograms } from '../../../programs/data/apiHooks';
+import ProgramCard from './ProgramCard';
+
+const messages = defineMessages({
+  searchPlaceholder: {
+    id: 'course-authoring.studio-home.programs.tab.search',
+    defaultMessage: 'Search programs...',
+  },
+  sortAZ: {
+    id: 'course-authoring.studio-home.programs.tab.sort.az',
+    defaultMessage: 'Name A-Z',
+  },
+  sortZA: {
+    id: 'course-authoring.studio-home.programs.tab.sort.za',
+    defaultMessage: 'Name Z-A',
+  },
+  emptyState: {
+    id: 'course-authoring.studio-home.programs.tab.empty',
+    defaultMessage: 'No programs yet. Click "New program" to create one.',
+  },
+  emptySearch: {
+    id: 'course-authoring.studio-home.programs.tab.empty-search',
+    defaultMessage: 'No programs match your search.',
+  },
+});
+
+type SortOrder = 'az' | 'za';
+
+const ProgramsTab: React.FC<{ showNewProgramContainer?: boolean }> = () => {
+  const intl = useIntl();
+  const [search, setSearch] = useState('');
+  const [sortOrder, setSortOrder] = useState<SortOrder>('az');
+
+  // Treat API errors the same as empty — don't show a jarring error banner for the list
+  const { data: programs = [], isLoading } = usePrograms();
+
+  const filteredPrograms = useMemo(() => {
+    let list = [...programs];
+
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      list = list.filter((p) => p.displayName.toLowerCase().includes(q));
+    }
+
+    list.sort((a, b) => (
+      sortOrder === 'az'
+        ? a.displayName.localeCompare(b.displayName)
+        : b.displayName.localeCompare(a.displayName)
+    ));
+
+    return list;
+  }, [programs, search, sortOrder]);
+
+  if (isLoading) {
+    return (
+      <Row className="m-0 mt-4 justify-content-center">
+        <LoadingSpinner />
+      </Row>
+    );
+  }
+
+  const sortLabel = sortOrder === 'az'
+    ? intl.formatMessage(messages.sortAZ)
+    : intl.formatMessage(messages.sortZA);
+
+  return (
+    <div className="mt-4">
+
+      {/* ── Search + sort bar ─────────────────────────────────────────── */}
+      <div className="d-flex mb-4">
+        <SearchField
+          onSubmit={setSearch}
+          onChange={setSearch}
+          value={search}
+          className="mr-4"
+          placeholder={intl.formatMessage(messages.searchPlaceholder)}
+        />
+        <Dropdown id="programs-sort-dropdown">
+          <Dropdown.Toggle
+            id="programs-sort-toggle"
+            variant="outline-primary"
+          >
+            {sortLabel}
+          </Dropdown.Toggle>
+          <Dropdown.Menu>
+            <Dropdown.Item
+              onClick={() => setSortOrder('az')}
+            >
+              <div className="d-flex align-items-center justify-content-between">
+                {intl.formatMessage(messages.sortAZ)}
+                {sortOrder === 'az' && <Icon src={Check} size="xs" className="ml-2" />}
+              </div>
+            </Dropdown.Item>
+            <Dropdown.Item
+              onClick={() => setSortOrder('za')}
+            >
+              <div className="d-flex align-items-center justify-content-between">
+                {intl.formatMessage(messages.sortZA)}
+                {sortOrder === 'za' && <Icon src={Check} size="xs" className="ml-2" />}
+              </div>
+            </Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
+      </div>
+
+      {/* ── List / empty state ────────────────────────────────────────── */}
+      {filteredPrograms.length === 0 ? (
+        <p className="text-muted">
+          {search.trim()
+            ? intl.formatMessage(messages.emptySearch)
+            : intl.formatMessage(messages.emptyState)}
+        </p>
+      ) : (
+        filteredPrograms.map((program) => (
+          <ProgramCard key={program.id} program={program} />
+        ))
+      )}
+    </div>
+  );
+};
+
+export default ProgramsTab;


### PR DESCRIPTION
Issue: https://github.com/edly-io/tutor-contrib-fbr/issues/7

## Summary                                                                                                                                                                
                                                                                                                                                                          
  - Introduces a full **Programs** authoring section to Studio Home for creating and managing training programs (STP, DST, IST, Seminar/Workshop) independent of courses    
  - Adds a **Target Audience** field to courses — available at creation time and on the Schedule & Details page                                                             
  - All core program CRUD, course assignment, instructor management, and learner enrollment are wired to real backend endpoints; only the "Enroll Batch" sub-feature remains
   mocked pending two backend endpoints                                                                                                                                     
                                                                                                                                                                            
  ---                                                                                                                                                                       
                                                                                                                                                                          
  ## What's New

  ### Programs Tab — Studio Home                                                                                                                                            
  - New **Programs** tab inserted between Courses and Libraries
  - Card-based list of all programs from `GET /fbr/api/programs/`                                                                                                           
  - Each `ProgramCard` shows name, org, type, run/batch, and status badge; links to the detail page                                                                         
  - **"New Program"** button opens an inline Formik creation form (org/type/run/name dropdowns populated from `GET /fbr/api/programs/config/`); on success, navigates       
  directly to the new program's detail page                                                                                                                                 
                                                                                                                                                                            
  **Files:** `src/studio-home/tabs-section/programs-tab/index.tsx`, `ProgramCard.tsx`, `src/studio-home/tabs-section/index.tsx`, `src/studio-home/StudioHome.tsx`,          
  `src/studio-home/create-new-program-form/index.jsx`                                                                                                                     
                                                                                                                                                                            
  ---                                                                                                                                                                     

  ### Program Detail Page (`/programs/:programId`)
  Four-tab layout with an unsaved-changes banner. `PATCH` always sent as `multipart/form-data` so `card_image` (Django `ImageField`) works without a separate upload
  endpoint.                                                                                                                                                                 
   
  **Program Details tab (editable)**                                                                                                                                        
  - Program Title, Short Description, Detailed Description                                                                                                                
  - Target Audience (`CreatableSelect` — select existing or type a new one; backend does `get_or_create` by name)                                                           
  - Start Date / End Date (date pickers)                                                                                                                                    
  - Status (`draft` / `active` / `archived` / `freezed`)                                                                                                                    
  - Is Featured (checkbox)                                                                                                                                                  
  - Card Image upload (click-to-upload with preview)                                                                                                                        
                                                                                                                                                                            
  **Right column (read-only)**                                                                                                                                            
  - Org, Program Type, Run, Program ID — immutable after creation                                                                                                           
                                                                                                                                                                            
  **File:** `src/programs/ProgramDetailPage.tsx`
                                                                                                                                                                            
  ---                                                                                                                                                                       
   
  ### Courses Tab                                                                                                                                                           
  - Lists courses already assigned to the program                                                                                                                         
  - **"Add Course"** opens `AddCourseModal` — paginated (5/page), searchable course list from `GET /fbr/api/programs/courses/`
  - **Immediate-add pattern**: clicking "Add" fires `POST /fbr/api/programs/<key>/courses/` immediately; React Query cache invalidation refreshes the list — no intermediate
   save button                                                                                                                                                              
  - **Remove** fires `DELETE /fbr/api/programs/<key>/courses/?course_id=<key>` (endpoint now live on backend)                                                               
                                                                                                                                                                            
  **Files:** `src/programs/courses-tab/CoursesTab.tsx`, `src/programs/courses-tab/AddCourseModal.tsx`                                                                     
                                                                                                                                                                            
  ---                                                                                                                                                                     

  ### Instructors Tab
  - Course dropdown (from the program's assigned courses)
  - Current course team fetched from Studio API: `GET /api/contentstore/v1/course_team/<courseId>`                                                                          
  - **"Add Instructor"** opens `AddInstructorModal` — searches platform users via `GET /fbr/api/programs/users/?role=instructor`; add fires `POST                           
  ${STUDIO_BASE_URL}/course_team/<id>/<email>` (role: staff)                                                                                                                
  - **Remove** fires `DELETE ${STUDIO_BASE_URL}/course_team/<id>/<email>`                                                                                                   
  - Per-row loading + error state; paginated list                                                                                                                           
                                                                                                                                                                            
  **Files:** `src/programs/instructors-tab/InstructorsTab.tsx`, `src/programs/instructors-tab/AddInstructorModal.tsx`                                                       
                                                                                                                                                                            
  ---                                                                                                                                                                     

  ### Enrollment Tab
  - Paginated/searchable list of enrolled learners from `GET /fbr/api/programs/<key>/learners/`
  - **"Enroll Learner"** opens `AddLearnerModal` — searches platform users (`GET /fbr/api/programs/users/?role=learner`); enroll fires `POST                                
  /fbr/api/programs/<key>/learners/`                                                                                                                                        
  - **"Unenroll"** fires `DELETE /fbr/api/programs/<key>/learners/?username=...`                                                                                            
  - **"Enroll Batch"** opens `EnrollBatchModal` (fully built UI; **backed by mock data** — see Mocked section)                                                              
                                                                                                                                                                            
  **Files:** `src/programs/enrollment-tab/EnrollmentTab.tsx`, `AddLearnerModal.tsx`, `EnrollBatchModal.tsx`                                                                 
                                                                                                                                                                            
  ---                                                                                                                                                                       
                                                                                                                                                                          
  ### Target Audience on Courses

  **Course creation form**                                                                                                                                                  
  `CreatableSelect` added to the "New Course" form. After the course is created, if an audience was selected, an `onAfterCreate` callback fires and `PATCH`es the audience
  via `PATCH /fbr/api/programs/courses/<key>/`.                                                                                                                             
                                                                                                                                                                          
  **Schedule & Details page**                                                                                                                                               
  New standalone `TargetAudienceSection` component inserted after `DetailsSection`. It uses React Query with its own save flow — completely independent of the Redux-based
  page save. Shows Save/Cancel only when dirty.                                                                                                                             
   
  **Files:** `src/schedule-and-details/target-audience-section/index.jsx`, `messages.js`, `src/schedule-and-details/index.jsx`,                                             
  `src/studio-home/create-new-course-form/index.jsx`, `src/generic/create-or-rerun-course/hooks.jsx`, `CreateOrRerunCourseForm.jsx`                                       
                                                                                                                                                                            
  ---                                                                                                                                                                     

  ## API Layer

  All calls are centralized in `src/programs/data/api.ts` — the only file that needs to change when backend URLs or field names change. Components only call hooks from     
  `apiHooks.ts`.
                                                                                                                                                                            
  <details>                                                                                                                                                               
  <summary>Frontend → Backend field name mapping</summary>
                                                                                                                                                                            
  | Frontend | Backend |
  |---|---|                                                                                                                                                                 
  | `displayName` | `name` |                                                                                                                                              
  | `org` | `organization` |
  | `programType` | `program_type` |
  | `run` | `batch` |
  | `shortDescription` | `description` |
  | `longDescription` | `long_description` |                                                                                                                                
  | `isFeatured` | `is_featured` |
  | `startDate` | `start_date` |                                                                                                                                            
  | `endDate` | `end_date` |                                                                                                                                              
  | `image` | `card_image` |
  | `id` | `program_key` |                                                                                                                                                  
  | `targetAudience` | `target_audience` |
                                                                                                                                                                            
  </details>                                                                                                                                                              

  ---

  ## Real vs. Mocked                                                                                                                                                        
   
  ### ✅ Wired to real backend endpoints                                                                                                                                    ─
                                                                                                                                                                          
  | Feature | Endpoint |
  |---|---|
  | Programs list | `GET /fbr/api/programs/` |                                                                                                                              
  | Program config | `GET /fbr/api/programs/config/` |
  | Program detail | `GET /fbr/api/programs/<key>/` |                                                                                                                       
  | Create program | `POST /fbr/api/programs/` |                                                                                                                          
  | Update program | `PATCH /fbr/api/programs/<key>/` (multipart) |                                                                                                         
  | Add course to program | `POST /fbr/api/programs/<key>/courses/` |
  | Remove course from program | `DELETE /fbr/api/programs/<key>/courses/?course_id=<key>` |                                                                                
  | Platform course list (paginated + search) | `GET /fbr/api/programs/courses/` |                                                                                          
  | Platform users (instructors / learners) | `GET /fbr/api/programs/users/?role=instructor\|learner` |
  | Current course team | `GET ${STUDIO_BASE_URL}/api/contentstore/v1/course_team/<id>` |                                                                                   
  | Add instructor to course | `POST ${STUDIO_BASE_URL}/course_team/<id>/<email>` |                                                                                       
  | Remove instructor from course | `DELETE ${STUDIO_BASE_URL}/course_team/<id>/<email>` |                                                                                  
  | Enrolled learners list | `GET /fbr/api/programs/<key>/learners/` |                                                                                                    
  | Enroll learner | `POST /fbr/api/programs/<key>/learners/` |                                                                                                             
  | Unenroll learner | `DELETE /fbr/api/programs/<key>/learners/?username=...` |                                                                                          
  | Target audiences list | `GET /fbr/api/programs/target-audiences/` |                                                                                                     
  | Course target audience (read) | `GET /fbr/api/programs/courses/<key>/` |                                                                                              
  | Course target audience (write) | `PATCH /fbr/api/programs/courses/<key>/` |                                                                                             
                                                                                                                                                                            
  ### 🚧 Mocked — pending backend endpoints
                                                                                                                                                                            
  | Feature | Mock location | Pending endpoint |                                                                                                                          
  |---|---|---|
  | Batch list in "Enroll Batch" modal | `api.ts` — `getBatches()` returns 5 hardcoded entries | `GET /fbr/api/programs/batches/` |
  | Batch user list in "Enroll Batch" modal | `api.ts` — `getBatchUsers(id)` returns hardcoded users per batch | `GET /fbr/api/programs/batches/<id>/users/` |              
                                                                                                                                                                            
  The `EnrollBatchModal` is fully implemented; only the two data-fetching functions need to be swapped once the backend ships.                                              
                                                                                                                                                    
  ---
                                                                                                                                                                            
  ## Tests                                                                                                                                                                

  | File | What it covers |                                                                                                                                                 
  |---|---|
  | `src/programs/courses-tab/CoursesTab.test.tsx` | Course list renders, Add button opens modal, remove fires mutation |                                                   
  | `src/programs/courses-tab/AddCourseModal.test.tsx` | Paginated course list, search, add-per-row fires `addCourseToProgram` |                                            
  | `src/programs/instructors-tab/InstructorsTab.test.tsx` | Course dropdown, instructor list, modal opens |                                                                
  | `src/programs/instructors-tab/AddInstructorModal.test.tsx` | Instructor list renders, add fires mutation |                                                              
  | `src/programs/enrollment-tab/EnrollmentTab.test.tsx` | Enrolled learner list, enroll/unenroll buttons fire correct mutations |                                          
  | `src/programs/enrollment-tab/AddLearnerModal.test.tsx` | Platform user search, add action, loading/error state |                                                        
                                                                                                                                                                            
  All tests use the project's standard `render()` wrapper from `src/testUtils.tsx` (Redux + React Query + Router) and mock implementations in                               
  `src/programs/data/api.mock.ts`.                                                                                                                                        
                                                                                                                                                                            
  ---                                                                                                                                                                     

  ## Routes Added

  /programs              → StudioHome (Programs tab active)                                                                                                                 
  /programs/:programId   → ProgramDetailPage
                                                                                                                                                                            
  Registered in `src/index.jsx`.                                                                                                                                          
                                                                                                    