### PR TITLE
temp: Grading Settings Save Button Stuck in Pending State

### DIFF
--- a/src/grading-settings/GradingSettings.jsx
+++ b/src/grading-settings/GradingSettings.jsx
@@ -42,7 +42,7 @@ const GradingSettings = ({ courseId }) => {
   } = useCourseSettings(courseId);
   const {
     mutate: updateGradingSettings,
-    isLoading: savePending,
+    isPending: savePending,
     isSuccess: savingStatus,
     isError: savingFailed,
   } = useGradingSettingUpdater(courseId);


### PR DESCRIPTION
## Description

[Edly-8278](https://projects.arbisoft.com/arbisoft/browse/EDLYPRODUCT-8278/) | Cherry-pick of [openedx/frontend-app-authoring#2614](https://github.com/openedx/frontend-app-authoring/pull/2614).

After saving grading settings, the save button remained stuck in a loading/spinner state and the "You've made some changes" banner never dismissed, even though the save succeeded on the backend.

## Changes
- Renamed `isLoading` to `isPending` in `useGradingSettingUpdater` destructuring to align with TanStack Query v5 API

## Test plan
- [ ] Make a change on the Grading settings page and click "Save changes"
- [ ] Verify the save button spinner clears after save completes
- [ ] Verify the "You've made some changes" banner dismisses after save completes
- [ ] Verify the green success alert appears at the top of the page

---