### PR TITLE
feat: implement program access management and permissions

### DIFF
--- a/src/course-lifecycle/components/BlockCommentsPanel.test.tsx
+++ b/src/course-lifecycle/components/BlockCommentsPanel.test.tsx
@@ -76,12 +76,12 @@ describe('<BlockCommentsPanel />', () => {
     expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
   });
 
-  it('does not show "Delete" button for comment authored by another user', () => {
+  it('shows "Delete" button for another user comment because Instructor+ may moderate comments', () => {
     const comment = mockBlockReviewComment({ author: 'some_other_user' });
     mockUseBlockComments.mockReturnValue({ data: [comment], isLoading: false });
     render(<BlockCommentsPanel usageKey={usageKey} />);
     expandPanel();
-    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
   });
 
   it('calls resolveMutation.mutate with comment id when Resolve is clicked', () => {

--- a/src/course-lifecycle/components/BlockCommentsPanel.tsx
+++ b/src/course-lifecycle/components/BlockCommentsPanel.tsx
@@ -6,7 +6,6 @@ import {
   Form,
   Spinner,
 } from '@openedx/paragon';
-import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 
 import type { BlockReviewComment } from '../data/types';
 import {
@@ -65,12 +64,11 @@ const ReplyForm = ({ commentId, usageKey, onCancel }: ReplyFormProps) => {
 interface CommentRowProps {
   comment: BlockReviewComment;
   usageKey: string;
-  currentUsername: string | undefined;
   isReply?: boolean;
 }
 
 const CommentRow = ({
-  comment, usageKey, currentUsername, isReply = false,
+  comment, usageKey, isReply = false,
 }: CommentRowProps) => {
   const [showReplyForm, setShowReplyForm] = useState(false);
   const resolveMutation = useResolveComment(usageKey);
@@ -93,17 +91,15 @@ const CommentRow = ({
               Resolve
             </Button>
           )}
-          {comment.author === currentUsername && (
-            <Button
-              variant="link"
-              size="sm"
-              className="p-0 text-danger"
-              disabled={deleteMutation.isPending}
-              onClick={() => deleteMutation.mutate(comment.id)}
-            >
-              Delete
-            </Button>
-          )}
+          <Button
+            variant="link"
+            size="sm"
+            className="p-0 text-danger"
+            disabled={deleteMutation.isPending}
+            onClick={() => deleteMutation.mutate(comment.id)}
+          >
+            Delete
+          </Button>
         </div>
       </div>
       <p className="small mb-1">{comment.comment}</p>
@@ -115,7 +111,6 @@ const CommentRow = ({
           key={reply.id}
           comment={reply}
           usageKey={usageKey}
-          currentUsername={currentUsername}
           isReply
         />
       ))}
@@ -147,7 +142,6 @@ interface Props {
 }
 
 export const BlockCommentsPanel = ({ usageKey }: Props) => {
-  const currentUsername = getAuthenticatedUser()?.username;
   const { data: comments, isLoading } = useBlockComments(usageKey);
 
   return (
@@ -168,7 +162,6 @@ export const BlockCommentsPanel = ({ usageKey }: Props) => {
             key={c.id}
             comment={c}
             usageKey={usageKey}
-            currentUsername={currentUsername}
           />
         ))}
       </Collapsible.Body>

--- a/src/course-lifecycle/components/CourseCommentsPanel.test.tsx
+++ b/src/course-lifecycle/components/CourseCommentsPanel.test.tsx
@@ -84,12 +84,12 @@ describe('<CourseCommentsPanel />', () => {
     expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
   });
 
-  it('does not show "Delete" button for comment authored by another user', () => {
+  it('shows "Delete" button for another user comment because Instructor+ may moderate comments', () => {
     const comment = mockBlockReviewComment({ author: 'another_user' });
     mockUseCourseComments.mockReturnValue({ data: [comment], isLoading: false });
     render(<CourseCommentsPanel courseId={courseId} />);
     expandPanel();
-    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
   });
 
   it('calls resolveComment api when Resolve is clicked', async () => {

--- a/src/course-lifecycle/components/CourseCommentsPanel.tsx
+++ b/src/course-lifecycle/components/CourseCommentsPanel.tsx
@@ -7,7 +7,6 @@ import {
   Spinner,
 } from '@openedx/paragon';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 
 import type { BlockReviewComment } from '../data/types';
 import { deleteComment, resolveComment } from '../data/api';
@@ -62,7 +61,6 @@ const CourseReplyForm = ({ commentId, courseId, onCancel }: CourseReplyFormProps
 interface CourseCommentRowProps {
   comment: BlockReviewComment;
   courseId: string;
-  currentUsername: string | undefined;
   resolveMutationPending: boolean;
   deleteMutationPending: boolean;
   onResolve: (id: number) => void;
@@ -71,7 +69,7 @@ interface CourseCommentRowProps {
 }
 
 const CourseCommentRow = ({
-  comment, courseId, currentUsername,
+  comment, courseId,
   resolveMutationPending, deleteMutationPending,
   onResolve, onDelete, isReply = false,
 }: CourseCommentRowProps) => {
@@ -94,17 +92,15 @@ const CourseCommentRow = ({
               Resolve
             </Button>
           )}
-          {comment.author === currentUsername && (
-            <Button
-              variant="link"
-              size="sm"
-              className="p-0 text-danger"
-              disabled={deleteMutationPending}
-              onClick={() => onDelete(comment.id)}
-            >
-              Delete
-            </Button>
-          )}
+          <Button
+            variant="link"
+            size="sm"
+            className="p-0 text-danger"
+            disabled={deleteMutationPending}
+            onClick={() => onDelete(comment.id)}
+          >
+            Delete
+          </Button>
         </div>
       </div>
       <p className="small mb-1">{comment.comment}</p>
@@ -116,7 +112,6 @@ const CourseCommentRow = ({
           key={reply.id}
           comment={reply}
           courseId={courseId}
-          currentUsername={currentUsername}
           resolveMutationPending={resolveMutationPending}
           deleteMutationPending={deleteMutationPending}
           onResolve={onResolve}
@@ -152,7 +147,6 @@ interface Props {
 
 export const CourseCommentsPanel = ({ courseId }: Props) => {
   const queryClient = useQueryClient();
-  const currentUsername = getAuthenticatedUser()?.username;
   const { data: comments, isLoading } = useCourseComments(courseId);
 
   const resolveMutation = useMutation({
@@ -187,7 +181,6 @@ export const CourseCommentsPanel = ({ courseId }: Props) => {
             key={c.id}
             comment={c}
             courseId={courseId}
-            currentUsername={currentUsername}
             resolveMutationPending={resolveMutation.isPending}
             deleteMutationPending={deleteMutation.isPending}
             onResolve={(id) => resolveMutation.mutate(id)}

--- a/src/course-lifecycle/components/CourseLifecycleSection.test.tsx
+++ b/src/course-lifecycle/components/CourseLifecycleSection.test.tsx
@@ -45,14 +45,26 @@ describe('<CourseLifecycleSection />', () => {
     expect(container.querySelector('.spinner-border')).toBeInTheDocument();
   });
 
-  it('shows "not enrolled in review workflow" when there is an error', () => {
+  it('shows a load error for non-404 failures', () => {
     mockUseCourseAggregateState.mockReturnValue({
       data: undefined,
       isLoading: false,
       error: new Error('Not found'),
     });
     render(<CourseLifecycleSection courseId={courseId} />);
-    expect(screen.getByText(/not enrolled in the review workflow/i)).toBeInTheDocument();
+    expect(screen.getByText(/could not load course review status/i)).toBeInTheDocument();
+  });
+
+  it('does not render lifecycle UI when access is denied', () => {
+    mockUseCourseAggregateState.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      isAccessPending: false,
+      isAccessDenied: true,
+    });
+    const { container } = render(<CourseLifecycleSection courseId={courseId} />);
+    expect(container.querySelector('.lifecycle-section')).not.toBeInTheDocument();
   });
 
   it('shows "not enrolled in review workflow" when data is null', () => {

--- a/src/course-lifecycle/components/CourseLifecycleSection.tsx
+++ b/src/course-lifecycle/components/CourseLifecycleSection.tsx
@@ -35,7 +35,9 @@ interface Props {
 export const CourseLifecycleSection = ({ courseId }: Props) => {
   const dispatch = useDispatch();
 
-  const { data, isLoading, error } = useCourseAggregateState(courseId);
+  const {
+    data, isLoading, error, isAccessPending, isAccessDenied,
+  } = useCourseAggregateState(courseId);
   const submitMutation = useSubmitCourseForReview(courseId);
   const approveMutation = useApproveCourse(courseId);
   const requestChangesMutation = useRequestCourseChanges(courseId);
@@ -46,11 +48,20 @@ export const CourseLifecycleSection = ({ courseId }: Props) => {
     showRequestForm, requestComment, setRequestComment, open, cancel, submit,
   } = useRequestChangesForm(requestChangesMutation);
 
+  if (isAccessPending || isAccessDenied || (error as any)?.response?.status === 403) {
+    return null;
+  }
+
+  const errorStatus = (error as any)?.response?.status;
+
   return (
     <div className="lifecycle-section">
       {isLoading && <Spinner animation="border" size="sm" className="my-1" />}
-      {!isLoading && (error || !data) && (
+      {!isLoading && (errorStatus === 404 || (!error && !data)) && (
         <p className="x-small text-muted mb-0">This course is not enrolled in the review workflow.</p>
+      )}
+      {!isLoading && error && errorStatus !== 404 && (
+        <p className="x-small text-muted mb-0">Could not load course review status.</p>
       )}
       {!isLoading && data && (
         <>

--- a/src/course-lifecycle/components/LifecycleModal.tsx
+++ b/src/course-lifecycle/components/LifecycleModal.tsx
@@ -16,9 +16,15 @@ interface Props {
 export const LifecycleModal = ({
   isOpen, onClose, blockId, displayName, hasChanges,
 }: Props) => {
-  const { data: blockState, isLoading } = useBlockState(blockId);
+  const {
+    data: blockState, isLoading, isAccessPending, isAccessDenied,
+  } = useBlockState(blockId, { enabled: isOpen });
 
   const effectiveState = (!hasChanges && blockState?.state === 'draft') ? 'published' : blockState?.state;
+
+  if (isAccessPending || isAccessDenied) {
+    return null;
+  }
 
   return (
     <ModalDialog

--- a/src/course-lifecycle/components/LifecycleSection.tsx
+++ b/src/course-lifecycle/components/LifecycleSection.tsx
@@ -17,7 +17,9 @@ export const LifecycleSection = ({
   usageKey, title = 'Review Status', hasChanges,
 }: Props) => {
   const queryClient = useQueryClient();
-  const { data: blockState, isLoading, error } = useBlockState(usageKey);
+  const {
+    data: blockState, isLoading, error, isAccessPending, isAccessDenied,
+  } = useBlockState(usageKey);
 
   // When the unit gains unpublished changes (e.g. a new component was added),
   // the backend signals have already transitioned the block PUBLISHED → DRAFT.
@@ -30,6 +32,10 @@ export const LifecycleSection = ({
   }, [hasChanges, usageKey]);
 
   const effectiveState = (!hasChanges && blockState?.state === 'draft') ? 'published' : blockState?.state;
+
+  if (isAccessPending || isAccessDenied || (error as any)?.response?.status === 403) {
+    return null;
+  }
 
   return (
     <div className="lifecycle-section my-3 border-top pt-3">

--- a/src/course-lifecycle/data/accessHooks.ts
+++ b/src/course-lifecycle/data/accessHooks.ts
@@ -1,0 +1,13 @@
+import { useCurrentFbrProfile } from '@src/fbr-access/apiHooks';
+
+import { getLifecycleCapabilities } from './permissions';
+
+export const useLifecycleAccess = () => {
+  const query = useCurrentFbrProfile();
+
+  return {
+    ...query,
+    profile: query.data,
+    capabilities: getLifecycleCapabilities(query.data?.roles),
+  };
+};

--- a/src/course-lifecycle/data/apiHooks.ts
+++ b/src/course-lifecycle/data/apiHooks.ts
@@ -18,6 +18,7 @@ import {
   submitCourseForReview,
   submitForReview,
 } from './api';
+import { useLifecycleAccess } from './accessHooks';
 
 export const lifecycleQueryKeys = {
   blockState: (usageKey: string) => ['lifecycle', 'block', usageKey, 'state'],
@@ -27,21 +28,39 @@ export const lifecycleQueryKeys = {
   bulkCourseStates: (courseIds: string[]) => ['lifecycle', 'courses', 'bulk', ...courseIds],
 };
 
-export const useBulkCourseAggregateStates = (courseIds: string[]) => useQuery({
-  queryKey: lifecycleQueryKeys.bulkCourseStates(courseIds),
-  queryFn: () => getBulkCourseAggregateStates(courseIds),
-  enabled: courseIds.length > 0,
-});
+export const useBulkCourseAggregateStates = (courseIds: string[], options?: { enabled?: boolean }) => {
+  const { isPending: isAccessPending, capabilities } = useLifecycleAccess();
+  const isAccessDenied = !isAccessPending && !capabilities.canAccessLifecycle;
+  const query = useQuery({
+    queryKey: lifecycleQueryKeys.bulkCourseStates(courseIds),
+    queryFn: () => getBulkCourseAggregateStates(courseIds),
+    enabled: (options?.enabled ?? true)
+      && courseIds.length > 0
+      && !isAccessPending
+      && capabilities.canAccessLifecycle,
+  });
 
-export const useCourseAggregateState = (courseId: string, options?: { enabled?: boolean }) => useQuery({
-  queryKey: lifecycleQueryKeys.courseState(courseId),
-  queryFn: () => getCourseAggregateState(courseId),
-  enabled: options?.enabled ?? true,
-  retry: (failureCount, error: any) => {
-    if (error?.response?.status === 404) { return false; }
-    return failureCount < 3;
-  },
-});
+  return { ...query, isAccessPending, isAccessDenied };
+};
+
+export const useCourseAggregateState = (courseId: string, options?: { enabled?: boolean }) => {
+  const { isPending: isAccessPending, capabilities } = useLifecycleAccess();
+  const isAccessDenied = !isAccessPending && !capabilities.canAccessLifecycle;
+  const query = useQuery({
+    queryKey: lifecycleQueryKeys.courseState(courseId),
+    queryFn: () => getCourseAggregateState(courseId),
+    enabled: (options?.enabled ?? true)
+      && !!courseId
+      && !isAccessPending
+      && capabilities.canAccessLifecycle,
+    retry: (failureCount, error: any) => {
+      if ([403, 404].includes(error?.response?.status)) { return false; }
+      return failureCount < 3;
+    },
+  });
+
+  return { ...query, isAccessPending, isAccessDenied };
+};
 
 export const useSubmitCourseForReview = (courseId: string) => {
   const queryClient = useQueryClient();
@@ -75,27 +94,50 @@ export const useRequestCourseChanges = (courseId: string) => {
   });
 };
 
-export const useBlockState = (usageKey: string) => useQuery({
-  queryKey: lifecycleQueryKeys.blockState(usageKey),
-  queryFn: () => getBlockState(usageKey),
-  // Treat 404 as "unmanaged block" — return null instead of throwing
-  retry: (failureCount, error: any) => {
-    if (error?.response?.status === 404) {
-      return false;
-    }
-    return failureCount < 3;
-  },
-});
+export const useBlockState = (usageKey: string, options?: { enabled?: boolean }) => {
+  const { isPending: isAccessPending, capabilities } = useLifecycleAccess();
+  const isAccessDenied = !isAccessPending && !capabilities.canAccessLifecycle;
+  const query = useQuery({
+    queryKey: lifecycleQueryKeys.blockState(usageKey),
+    queryFn: () => getBlockState(usageKey),
+    enabled: (options?.enabled ?? true)
+      && !!usageKey
+      && !isAccessPending
+      && capabilities.canAccessLifecycle,
+    retry: (failureCount, error: any) => {
+      if ([403, 404].includes(error?.response?.status)) {
+        return false;
+      }
+      return failureCount < 3;
+    },
+  });
 
-export const useBlockComments = (usageKey: string) => useQuery({
-  queryKey: lifecycleQueryKeys.blockComments(usageKey),
-  queryFn: () => getBlockComments(usageKey),
-});
+  return { ...query, isAccessPending, isAccessDenied };
+};
 
-export const useCourseComments = (courseId: string) => useQuery({
-  queryKey: lifecycleQueryKeys.courseComments(courseId),
-  queryFn: () => getCourseComments(courseId),
-});
+export const useBlockComments = (usageKey: string, options?: { enabled?: boolean }) => {
+  const { isPending: isAccessPending, capabilities } = useLifecycleAccess();
+  return useQuery({
+    queryKey: lifecycleQueryKeys.blockComments(usageKey),
+    queryFn: () => getBlockComments(usageKey),
+    enabled: (options?.enabled ?? true)
+      && !!usageKey
+      && !isAccessPending
+      && capabilities.canManageComments,
+  });
+};
+
+export const useCourseComments = (courseId: string, options?: { enabled?: boolean }) => {
+  const { isPending: isAccessPending, capabilities } = useLifecycleAccess();
+  return useQuery({
+    queryKey: lifecycleQueryKeys.courseComments(courseId),
+    queryFn: () => getCourseComments(courseId),
+    enabled: (options?.enabled ?? true)
+      && !!courseId
+      && !isAccessPending
+      && capabilities.canManageComments,
+  });
+};
 
 export const useSubmitForReview = (usageKey: string) => {
   const queryClient = useQueryClient();

--- a/src/course-lifecycle/data/permissions.test.ts
+++ b/src/course-lifecycle/data/permissions.test.ts
@@ -1,0 +1,60 @@
+import {
+  getLifecycleCapabilities,
+  getLifecyclePublishPermission,
+} from './permissions';
+
+describe('course lifecycle permissions', () => {
+  it.each([
+    ['super_admin', true],
+    ['middle_admin', true],
+    ['data_admin', true],
+    ['instructor', false],
+  ] as const)('allows %s to access lifecycle with the expected review access', (role, canReviewLifecycle) => {
+    expect(getLifecycleCapabilities([role])).toEqual({
+      canAccessLifecycle: true,
+      canSubmitLifecycle: true,
+      canReviewLifecycle,
+      canManageComments: true,
+    });
+  });
+
+  it.each([
+    [['trainee']],
+    [[]],
+  ] as const)('denies lifecycle access for roles %j', (roles) => {
+    expect(getLifecycleCapabilities([...roles])).toEqual({
+      canAccessLifecycle: false,
+      canSubmitLifecycle: false,
+      canReviewLifecycle: false,
+      canManageComments: false,
+    });
+  });
+
+  it('blocks native publishing while lifecycle access or state is loading', () => {
+    expect(getLifecyclePublishPermission({
+      data: undefined,
+      error: null,
+      isLoading: false,
+      isAccessPending: true,
+      isAccessDenied: false,
+    })).toBe(false);
+
+    expect(getLifecyclePublishPermission({
+      data: undefined,
+      error: null,
+      isLoading: true,
+      isAccessPending: false,
+      isAccessDenied: false,
+    })).toBe(false);
+  });
+
+  it('restores native publishing only when the block is not lifecycle-managed', () => {
+    expect(getLifecyclePublishPermission({
+      data: undefined,
+      error: { response: { status: 404 } },
+      isLoading: false,
+      isAccessPending: false,
+      isAccessDenied: false,
+    })).toBeUndefined();
+  });
+});

--- a/src/course-lifecycle/data/permissions.ts
+++ b/src/course-lifecycle/data/permissions.ts
@@ -1,0 +1,66 @@
+import type { FbrRole } from '@src/fbr-access/types';
+import type { BlockReviewState } from './types';
+
+export interface LifecycleCapabilities {
+  canAccessLifecycle: boolean;
+  canSubmitLifecycle: boolean;
+  canReviewLifecycle: boolean;
+  canManageComments: boolean;
+}
+
+const NO_LIFECYCLE_ACCESS: LifecycleCapabilities = {
+  canAccessLifecycle: false,
+  canSubmitLifecycle: false,
+  canReviewLifecycle: false,
+  canManageComments: false,
+};
+
+export const getLifecycleCapabilities = (roles: FbrRole[] = []): LifecycleCapabilities => {
+  const roleSet = new Set(roles);
+  const isReviewer = roleSet.has('super_admin')
+    || roleSet.has('middle_admin')
+    || roleSet.has('data_admin');
+  const isInstructor = roleSet.has('instructor');
+  const canAccessLifecycle = isReviewer || isInstructor;
+
+  if (!canAccessLifecycle) {
+    return NO_LIFECYCLE_ACCESS;
+  }
+
+  return {
+    canAccessLifecycle: true,
+    canSubmitLifecycle: true,
+    canReviewLifecycle: isReviewer,
+    canManageComments: true,
+  };
+};
+
+interface LifecyclePublishQuery {
+  data?: BlockReviewState;
+  error?: unknown;
+  isLoading: boolean;
+  isAccessPending: boolean;
+  isAccessDenied: boolean;
+}
+
+export const getLifecyclePublishPermission = ({
+  data,
+  error,
+  isLoading,
+  isAccessPending,
+  isAccessDenied,
+}: LifecyclePublishQuery): boolean | undefined => {
+  if (isAccessPending || isAccessDenied || isLoading) {
+    return false;
+  }
+
+  if ((error as any)?.response?.status === 404) {
+    return undefined;
+  }
+
+  if (error) {
+    return false;
+  }
+
+  return data?.canPublish;
+};

--- a/src/course-outline/outline-sidebar/OutlineSidebar.jsx
+++ b/src/course-outline/outline-sidebar/OutlineSidebar.jsx
@@ -6,10 +6,12 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import { HelpSidebar } from '../../generic/help-sidebar';
 import { useHelpUrls } from '../../help-urls/hooks';
 import { CourseLifecycleSection } from '../../course-lifecycle';
+import { useLifecycleAccess } from '../../course-lifecycle/data/accessHooks';
 import { getFormattedSidebarMessages } from './utils';
 
 const OutlineSideBar = ({ courseId }) => {
   const intl = useIntl();
+  const { capabilities } = useLifecycleAccess();
   const {
     visibility: learnMoreVisibilityUrl,
     grading: learnMoreGradingUrl,
@@ -32,11 +34,13 @@ const OutlineSideBar = ({ courseId }) => {
       className="outline-sidebar mt-4"
       data-testid="outline-sidebar"
     >
-      <div className="outline-sidebar-section mb-3">
-        <h4 className="help-sidebar-about-title">Course Review Status</h4>
-        <CourseLifecycleSection courseId={courseId} />
-        <hr className="my-3.5" />
-      </div>
+      {capabilities.canAccessLifecycle && (
+        <div className="outline-sidebar-section mb-3">
+          <h4 className="help-sidebar-about-title">Course Review Status</h4>
+          <CourseLifecycleSection courseId={courseId} />
+          <hr className="my-3.5" />
+        </div>
+      )}
       {sidebarMessages.map(({ title, descriptions, link }, index) => {
         const isLastSection = index === sidebarMessages.length - 1;
 

--- a/src/course-outline/section-card/SectionCard.tsx
+++ b/src/course-outline/section-card/SectionCard.tsx
@@ -28,6 +28,7 @@ import { UpstreamInfoIcon } from '@src/generic/upstream-info-icon';
 import type { XBlock } from '@src/data/types';
 import { useBlockSyncData, usePostSyncCallback, useSaveStatusCloseForm } from '@src/course-outline/hooks';
 import { useBlockState } from '@src/course-lifecycle/data/apiHooks';
+import { getLifecyclePublishPermission } from '@src/course-lifecycle/data/permissions';
 import { LifecycleModal } from '@src/course-lifecycle/components/LifecycleModal';
 import { useRefreshOnPublish } from '@src/course-lifecycle/hooks';
 import messages from './messages';
@@ -135,7 +136,9 @@ const SectionCard = ({
     upstreamInfo,
   } = section;
 
-  const { data: blockLifecycleState } = useBlockState(id);
+  const blockLifecycleQuery = useBlockState(id);
+  const { data: blockLifecycleState } = blockLifecycleQuery;
+  const lifecyclePublishPermission = getLifecyclePublishPermission(blockLifecycleQuery);
 
   useRefreshOnPublish(blockLifecycleState?.state, () => dispatch(fetchCourseSectionQuery([id])));
 
@@ -291,7 +294,7 @@ const SectionCard = ({
                 namePrefix={namePrefix}
                 actions={actions}
                 readyToSync={upstreamInfo?.readyToSync}
-                canPublish={blockLifecycleState?.canPublish}
+                canPublish={lifecyclePublishPermission}
                 lifecycleState={blockLifecycleState?.state}
                 onClickLifecycle={openLifecycleModal}
               />

--- a/src/course-outline/subsection-card/SubsectionCard.tsx
+++ b/src/course-outline/subsection-card/SubsectionCard.tsx
@@ -29,6 +29,7 @@ import { PreviewLibraryXBlockChanges } from '@src/course-unit/preview-changes';
 import type { XBlock } from '@src/data/types';
 import { useBlockSyncData, usePostSyncCallback, useSaveStatusCloseForm } from '@src/course-outline/hooks';
 import { useBlockState } from '@src/course-lifecycle/data/apiHooks';
+import { getLifecyclePublishPermission } from '@src/course-lifecycle/data/permissions';
 import { LifecycleModal } from '@src/course-lifecycle/components/LifecycleModal';
 import { useRefreshOnPublish } from '@src/course-lifecycle/hooks';
 import messages from './messages';
@@ -117,7 +118,9 @@ const SubsectionCard = ({
     upstreamInfo,
   } = subsection;
 
-  const { data: blockLifecycleState } = useBlockState(id);
+  const blockLifecycleQuery = useBlockState(id);
+  const { data: blockLifecycleState } = blockLifecycleQuery;
+  const lifecyclePublishPermission = getLifecyclePublishPermission(blockLifecycleQuery);
 
   useRefreshOnPublish(blockLifecycleState?.state, () => dispatch(fetchCourseSectionQuery([section.id])));
 
@@ -296,7 +299,7 @@ const SubsectionCard = ({
                 isSequential
                 extraActionsComponent={extraActionsComponent}
                 readyToSync={upstreamInfo?.readyToSync}
-                canPublish={blockLifecycleState?.canPublish}
+                canPublish={lifecyclePublishPermission}
                 lifecycleState={blockLifecycleState?.state}
                 onClickLifecycle={openLifecycleModal}
               />

--- a/src/course-outline/unit-card/UnitCard.tsx
+++ b/src/course-outline/unit-card/UnitCard.tsx
@@ -22,6 +22,7 @@ import { PreviewLibraryXBlockChanges } from '@src/course-unit/preview-changes';
 import { useBlockSyncData, usePostSyncCallback, useSaveStatusCloseForm } from '@src/course-outline/hooks';
 import type { XBlock } from '@src/data/types';
 import { useBlockState } from '@src/course-lifecycle/data/apiHooks';
+import { getLifecyclePublishPermission } from '@src/course-lifecycle/data/permissions';
 import { LifecycleModal } from '@src/course-lifecycle/components/LifecycleModal';
 import { useRefreshOnPublish } from '@src/course-lifecycle/hooks';
 
@@ -96,7 +97,9 @@ const UnitCard = ({
   // Fetch lifecycle state to determine publish permission for this unit.
   // canPublish encodes: state===APPROVED AND is_publishable.
   // React Query caches per usage key; undefined when block is not in lifecycle system (404).
-  const { data: blockLifecycleState } = useBlockState(id);
+  const blockLifecycleQuery = useBlockState(id);
+  const { data: blockLifecycleState } = blockLifecycleQuery;
+  const lifecyclePublishPermission = getLifecyclePublishPermission(blockLifecycleQuery);
 
   useRefreshOnPublish(blockLifecycleState?.state, () => dispatch(fetchCourseSectionQuery([section.id])));
 
@@ -243,7 +246,7 @@ const UnitCard = ({
             parentInfo={parentInfo}
             extraActionsComponent={extraActionsComponent}
             readyToSync={upstreamInfo?.readyToSync}
-            canPublish={blockLifecycleState?.canPublish}
+            canPublish={lifecyclePublishPermission}
             lifecycleState={blockLifecycleState?.state}
             onClickLifecycle={openLifecycleModal}
           />

--- a/src/course-unit/sidebar/PublishControls.tsx
+++ b/src/course-unit/sidebar/PublishControls.tsx
@@ -11,6 +11,7 @@ import { getCourseUnitData } from '../data/selectors';
 import messages from './messages';
 import ModalNotification from '../../generic/modal-notification';
 import { LifecycleSection, useBlockState } from '../../course-lifecycle';
+import { getLifecyclePublishPermission } from '../../course-lifecycle/data/permissions';
 
 interface PublishControlsProps {
   blockId?: string,
@@ -19,7 +20,8 @@ interface PublishControlsProps {
 const PublishControls = ({ blockId }: PublishControlsProps) => {
   const unitData = useSelector(getCourseUnitData);
   const { hasChanges } = unitData || {};
-  const { data: blockLifecycleState } = useBlockState(blockId ?? '');
+  const blockLifecycleQuery = useBlockState(blockId ?? '');
+  const lifecyclePublishPermission = getLifecyclePublishPermission(blockLifecycleQuery);
   const {
     title,
     locationId,
@@ -72,7 +74,7 @@ const PublishControls = ({ blockId }: PublishControlsProps) => {
         openVisibleModal={openVisibleModal}
         handlePublishing={handleCourseUnitPublish}
         visibleToStaffOnly={visibleToStaffOnly}
-        hidePublishButton={!!blockLifecycleState}
+        hidePublishButton={lifecyclePublishPermission !== undefined}
       />
       <ModalNotification
         title={intl.formatMessage(messages.modalDiscardUnitChangesTitle)}

--- a/src/fbr-access/api.ts
+++ b/src/fbr-access/api.ts
@@ -1,0 +1,17 @@
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+import type { FbrUserProfile } from './types';
+
+export const getCurrentFbrProfileUrl = () => `${getConfig().LMS_BASE_URL}/fbr/api/biodata/v1/users/me/`;
+
+export const getCurrentFbrProfile = async (): Promise<FbrUserProfile> => {
+  const { data } = await getAuthenticatedHttpClient().get(getCurrentFbrProfileUrl());
+  return {
+    id: data.id,
+    fullName: data.full_name,
+    email: data.email,
+    roles: Array.isArray(data.roles) ? data.roles : [],
+    city: data.city ?? null,
+  };
+};

--- a/src/fbr-access/apiHooks.ts
+++ b/src/fbr-access/apiHooks.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getCurrentFbrProfile } from './api';
+
+export const currentFbrProfileQueryKey = ['currentFbrProfile'];
+
+export const useCurrentFbrProfile = () => useQuery({
+  queryKey: currentFbrProfileQueryKey,
+  queryFn: getCurrentFbrProfile,
+  staleTime: 5 * 60 * 1000,
+  retry: false,
+});

--- a/src/fbr-access/types.ts
+++ b/src/fbr-access/types.ts
@@ -1,0 +1,17 @@
+export type FbrRole =
+  | 'super_admin'
+  | 'middle_admin'
+  | 'data_admin'
+  | 'instructor'
+  | 'trainee';
+
+export interface FbrUserProfile {
+  id: number;
+  fullName: string;
+  email: string;
+  roles: FbrRole[];
+  city: {
+    id: number;
+    name: string;
+  } | null;
+}

--- a/src/programs/ProgramDetailPage.test.tsx
+++ b/src/programs/ProgramDetailPage.test.tsx
@@ -1,0 +1,102 @@
+import {
+  initializeMocks, render, screen,
+} from '@src/testUtils';
+import ProgramDetailPage from './ProgramDetailPage';
+import { mockProgram } from './data/api.mock';
+import { getProgramCapabilities } from './data/permissions';
+
+const mockUpdateProgram = jest.fn();
+const mockUseProgramAccess = jest.fn();
+
+jest.mock('../header', () => function MockHeader() {
+  return <header>Header</header>;
+});
+jest.mock('./courses-tab/CoursesTab', () => function MockCoursesTab() {
+  return <div>Courses content</div>;
+});
+jest.mock('./instructors-tab/InstructorsTab', () => function MockInstructorsTab() {
+  return <div>Instructors content</div>;
+});
+jest.mock('./enrollment-tab/EnrollmentTab', () => function MockEnrollmentTab() {
+  return <div>Enrollment content</div>;
+});
+jest.mock('./data/apiHooks', () => ({
+  useProgramAccess: () => mockUseProgramAccess(),
+  useProgramDetail: () => ({
+    data: {
+      program: mockProgram({
+        displayName: 'Permission Test Program',
+        status: 'active',
+      }),
+      availableAudiences: [],
+    },
+    isLoading: false,
+    isError: false,
+  }),
+  useUpdateProgram: () => ({
+    mutateAsync: mockUpdateProgram,
+    isPending: false,
+  }),
+}));
+
+const renderPage = () => render(
+  <ProgramDetailPage />,
+  {
+    path: '/programs/:programId',
+    params: { programId: 'prog-key-1' },
+  },
+);
+
+describe('<ProgramDetailPage /> permissions', () => {
+  beforeEach(() => {
+    initializeMocks();
+    mockUseProgramAccess.mockReturnValue({
+      capabilities: getProgramCapabilities(['super_admin']),
+      isLoading: false,
+    });
+  });
+
+  it('allows Super Admins to save and change program status', () => {
+    renderPage();
+
+    expect(screen.getByRole('button', { name: 'Save Program' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Program Status' })).toBeInTheDocument();
+  });
+
+  it('lets Data Admins edit metadata without exposing archive status controls', () => {
+    mockUseProgramAccess.mockReturnValue({
+      capabilities: getProgramCapabilities(['data_admin']),
+      isLoading: false,
+    });
+
+    renderPage();
+
+    expect(screen.getByRole('button', { name: 'Save Program' })).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: 'Program Status' })).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue('Active')).toHaveAttribute('readonly');
+  });
+
+  it('renders instructor access as read-only', () => {
+    mockUseProgramAccess.mockReturnValue({
+      capabilities: getProgramCapabilities(['instructor']),
+      isLoading: false,
+    });
+
+    renderPage();
+
+    expect(screen.queryByRole('button', { name: 'Save Program' })).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue('Permission Test Program')).toHaveAttribute('readonly');
+    expect(screen.getByText('View program details')).toBeInTheDocument();
+  });
+
+  it('denies trainees direct access to program details', () => {
+    mockUseProgramAccess.mockReturnValue({
+      capabilities: getProgramCapabilities(['trainee']),
+      isLoading: false,
+    });
+
+    renderPage();
+
+    expect(screen.getByTestId('permissionDeniedAlert')).toBeInTheDocument();
+  });
+});

--- a/src/programs/ProgramDetailPage.tsx
+++ b/src/programs/ProgramDetailPage.tsx
@@ -23,8 +23,9 @@ import { useIntl, defineMessages } from '@edx/frontend-platform/i18n';
 import { StudioFooterSlot } from '@edx/frontend-component-footer';
 import Header from '../header';
 import { LoadingSpinner } from '../generic/Loading';
+import PermissionDeniedAlert from '../generic/PermissionDeniedAlert';
 import { ToastContext } from '../generic/toast-context';
-import { useProgramDetail, useUpdateProgram } from './data/apiHooks';
+import { useProgramAccess, useProgramDetail, useUpdateProgram } from './data/apiHooks';
 import CoursesTab from './courses-tab/CoursesTab';
 import InstructorsTab from './instructors-tab/InstructorsTab';
 import EnrollmentTab from './enrollment-tab/EnrollmentTab';
@@ -32,6 +33,7 @@ import EnrollmentTab from './enrollment-tab/EnrollmentTab';
 const messages = defineMessages({
   backToPrograms: { id: 'programs.detail.back', defaultMessage: '← Back to Programs' },
   configureSubtitle: { id: 'programs.detail.subtitle', defaultMessage: 'Configure your program details' },
+  viewSubtitle: { id: 'programs.detail.subtitle.read-only', defaultMessage: 'View program details' },
   saveProgram: { id: 'programs.detail.save', defaultMessage: 'Save Program' },
   saving: { id: 'programs.detail.saving', defaultMessage: 'Saving...' },
   savedSuccess: { id: 'programs.detail.saved', defaultMessage: 'Program saved successfully.' },
@@ -139,8 +141,15 @@ const ProgramDetailPage: React.FC = () => {
   const [activeTab, setActiveTab] = React.useState('details');
   const [imageFile, setImageFile] = React.useState<File | null>(null);
   const { showToast } = useContext(ToastContext);
+  const {
+    capabilities,
+    isLoading: isAccessLoading,
+  } = useProgramAccess();
 
-  const { data, isLoading, isError } = useProgramDetail(programId ?? '');
+  const { data, isLoading, isError } = useProgramDetail(
+    programId ?? '',
+    !isAccessLoading && capabilities.canAccessPrograms,
+  );
   const { mutateAsync: updateProgram, isPending: isSaving } = useUpdateProgram();
 
   const program = data?.program;
@@ -164,8 +173,22 @@ const ProgramDetailPage: React.FC = () => {
       displayName: Yup.string().trim().required(intl.formatMessage(messages.fieldTitleRequired)),
     }),
     onSubmit: async (values) => {
+      if (!capabilities.canEditProgram) {
+        return;
+      }
+
       try {
-        await updateProgram({ programId: programId ?? '', data: values, imageFile });
+        const updateData = capabilities.canArchiveProgram
+          ? values
+          : {
+            ...values,
+            status: undefined,
+          };
+        await updateProgram({
+          programId: programId ?? '',
+          data: updateData,
+          imageFile,
+        });
         setImageFile(null);
         showToast(intl.formatMessage(messages.savedSuccess));
       } catch {
@@ -190,12 +213,23 @@ const ProgramDetailPage: React.FC = () => {
   const statusBadgeVariant = STATUS_BADGE_VARIANT[formik.values.status ?? 'draft'] ?? 'secondary';
   const statusLabel = STATUS_OPTIONS.find((o) => o.value === formik.values.status)?.label ?? 'Draft';
 
-  if (isLoading) {
+  if (isAccessLoading || isLoading) {
     return (
       <>
         <Header isHiddenMainMenu />
         <Container size="xl" className="p-4 mt-3 d-flex justify-content-center">
           <LoadingSpinner />
+        </Container>
+      </>
+    );
+  }
+
+  if (!capabilities.canAccessPrograms) {
+    return (
+      <>
+        <Header isHiddenMainMenu />
+        <Container size="xl" className="p-4 mt-3">
+          <PermissionDeniedAlert />
         </Container>
       </>
     );
@@ -231,22 +265,28 @@ const ProgramDetailPage: React.FC = () => {
                 </Badge>
               )}
             </h2>
-            <p className="text-muted small mb-0">{intl.formatMessage(messages.configureSubtitle)}</p>
+            <p className="text-muted small mb-0">
+              {intl.formatMessage(
+                capabilities.isReadOnly ? messages.viewSubtitle : messages.configureSubtitle,
+              )}
+            </p>
           </div>
-          <StatefulButton
-            state={isSaving ? 'pending' : 'default'}
-            labels={{
-              default: intl.formatMessage(messages.saveProgram),
-              pending: intl.formatMessage(messages.saving),
-            }}
-            disabledStates={['pending']}
-            onClick={() => formik.handleSubmit()}
-            variant="primary"
-          />
+          {capabilities.canEditProgram && (
+            <StatefulButton
+              state={isSaving ? 'pending' : 'default'}
+              labels={{
+                default: intl.formatMessage(messages.saveProgram),
+                pending: intl.formatMessage(messages.saving),
+              }}
+              disabledStates={['pending']}
+              onClick={() => formik.handleSubmit()}
+              variant="primary"
+            />
+          )}
         </div>
 
         {/* ── Unsaved changes banner ──────────────────────────────────── */}
-        {formik.dirty && !formik.isSubmitting && (
+        {capabilities.canEditProgram && formik.dirty && !formik.isSubmitting && (
           <Alert variant="warning" className="mb-3">
             <div className="d-flex justify-content-between align-items-center">
               <span>
@@ -315,6 +355,7 @@ const ProgramDetailPage: React.FC = () => {
                           value={formik.values.displayName}
                           onChange={formik.handleChange}
                           onBlur={formik.handleBlur}
+                          readOnly={!capabilities.canEditProgram}
                         />
                         {formik.touched.displayName && formik.errors.displayName && (
                           <Form.Control.Feedback type="invalid">
@@ -334,6 +375,7 @@ const ProgramDetailPage: React.FC = () => {
                           value={formik.values.shortDescription ?? ''}
                           onChange={formik.handleChange}
                           onBlur={formik.handleBlur}
+                          readOnly={!capabilities.canEditProgram}
                         />
                         <Form.Text muted>{intl.formatMessage(messages.fieldShortDescHint)}</Form.Text>
                       </Form.Group>
@@ -349,6 +391,7 @@ const ProgramDetailPage: React.FC = () => {
                           value={formik.values.longDescription ?? ''}
                           onChange={formik.handleChange}
                           onBlur={formik.handleBlur}
+                          readOnly={!capabilities.canEditProgram}
                         />
                         <Form.Text muted>{intl.formatMessage(messages.fieldDetailedDescHint)}</Form.Text>
                       </Form.Group>
@@ -358,6 +401,7 @@ const ProgramDetailPage: React.FC = () => {
                         <Form.Label>{intl.formatMessage(messages.fieldAudience)}</Form.Label>
                         <CreatableSelect
                           isClearable
+                          isDisabled={!capabilities.canEditProgram}
                           options={audienceOptions}
                           value={selectedAudience}
                           onChange={(option) => formik.setFieldValue('targetAudience', option?.value ?? '')}
@@ -392,6 +436,7 @@ const ProgramDetailPage: React.FC = () => {
                               selected={formik.values.startDate ? new Date(formik.values.startDate) : null}
                               onChange={(date) => formik.setFieldValue('startDate', date ? date.toISOString().split('T')[0] : '')}
                               customInput={<DateInput placeholder="Select start date" />}
+                              disabled={!capabilities.canEditProgram}
                               dateFormat="MMMM d, yyyy"
                               popperPlacement="bottom-start"
                               showMonthDropdown
@@ -408,6 +453,7 @@ const ProgramDetailPage: React.FC = () => {
                               selected={formik.values.endDate ? new Date(formik.values.endDate) : null}
                               onChange={(date) => formik.setFieldValue('endDate', date ? date.toISOString().split('T')[0] : '')}
                               customInput={<DateInput placeholder="Select end date" />}
+                              disabled={!capabilities.canEditProgram}
                               dateFormat="MMMM d, yyyy"
                               minDate={formik.values.startDate ? new Date(formik.values.startDate) : undefined}
                               popperPlacement="bottom-start"
@@ -423,16 +469,20 @@ const ProgramDetailPage: React.FC = () => {
                       {/* Program Status */}
                       <Form.Group className="mb-4">
                         <Form.Label>{intl.formatMessage(messages.fieldStatus)}</Form.Label>
-                        <Form.Control
-                          as="select"
-                          name="status"
-                          value={formik.values.status ?? 'draft'}
-                          onChange={formik.handleChange}
-                        >
-                          {STATUS_OPTIONS.map((opt) => (
-                            <option key={opt.value} value={opt.value}>{opt.label}</option>
-                          ))}
-                        </Form.Control>
+                        {capabilities.canArchiveProgram ? (
+                          <Form.Control
+                            as="select"
+                            name="status"
+                            value={formik.values.status ?? 'draft'}
+                            onChange={formik.handleChange}
+                          >
+                            {STATUS_OPTIONS.map((opt) => (
+                              <option key={opt.value} value={opt.value}>{opt.label}</option>
+                            ))}
+                          </Form.Control>
+                        ) : (
+                          <Form.Control plaintext readOnly value={statusLabel} />
+                        )}
                       </Form.Group>
 
                       {/* Is Featured */}
@@ -443,6 +493,7 @@ const ProgramDetailPage: React.FC = () => {
                             id="isFeatured"
                             checked={formik.values.isFeatured ?? false}
                             onChange={(e) => formik.setFieldValue('isFeatured', e.target.checked)}
+                            disabled={!capabilities.canEditProgram}
                             className="mt-1 mr-2"
                             style={{
                               cursor: 'pointer', width: '16px', height: '16px', flexShrink: 0,
@@ -468,7 +519,7 @@ const ProgramDetailPage: React.FC = () => {
                     subtitle={intl.formatMessage(messages.sectionImageSubtitle)}
                   />
                   <Card.Section>
-                    {formik.values.image ? (
+                    {formik.values.image && (
                       <div>
                         <img
                           src={formik.values.image}
@@ -481,16 +532,19 @@ const ProgramDetailPage: React.FC = () => {
                             display: 'block',
                           }}
                         />
-                        <Button
-                          variant="outline-primary"
-                          size="sm"
-                          className="mt-3"
-                          onClick={() => document.getElementById('program-image-input')?.click()}
-                        >
-                          {intl.formatMessage(messages.imageChange)}
-                        </Button>
+                        {capabilities.canEditProgram && (
+                          <Button
+                            variant="outline-primary"
+                            size="sm"
+                            className="mt-3"
+                            onClick={() => document.getElementById('program-image-input')?.click()}
+                          >
+                            {intl.formatMessage(messages.imageChange)}
+                          </Button>
+                        )}
                       </div>
-                    ) : (
+                    )}
+                    {!formik.values.image && capabilities.canEditProgram && (
                       <button
                         type="button"
                         className="w-100 border-0 bg-transparent p-0"
@@ -521,13 +575,18 @@ const ProgramDetailPage: React.FC = () => {
                         </div>
                       </button>
                     )}
-                    <input
-                      id="program-image-input"
-                      type="file"
-                      accept="image/jpeg,image/png,image/webp"
-                      className="d-none"
-                      onChange={handleImageChange}
-                    />
+                    {!formik.values.image && !capabilities.canEditProgram && (
+                      <p className="text-muted mb-0">No program image uploaded.</p>
+                    )}
+                    {capabilities.canEditProgram && (
+                      <input
+                        id="program-image-input"
+                        type="file"
+                        accept="image/jpeg,image/png,image/webp"
+                        className="d-none"
+                        onChange={handleImageChange}
+                      />
+                    )}
                   </Card.Section>
                 </Card>
 
@@ -563,15 +622,25 @@ const ProgramDetailPage: React.FC = () => {
           </Tab>
 
           <Tab eventKey="courses" title={intl.formatMessage(messages.tabCourses)}>
-            <CoursesTab program={program} programId={programId ?? ''} />
+            <CoursesTab
+              program={program}
+              programId={programId ?? ''}
+              canManage={capabilities.canManageCourses}
+            />
           </Tab>
 
           <Tab eventKey="instructors" title={intl.formatMessage(messages.tabInstructors)}>
-            <InstructorsTab program={program} />
+            <InstructorsTab
+              program={program}
+              canManage={capabilities.canManageInstructors}
+            />
           </Tab>
 
           <Tab eventKey="enrollment" title={intl.formatMessage(messages.tabEnrollment)}>
-            <EnrollmentTab programId={programId ?? ''} />
+            <EnrollmentTab
+              programId={programId ?? ''}
+              canManage={capabilities.canManageEnrollment}
+            />
           </Tab>
         </Tabs>
 

--- a/src/programs/courses-tab/CoursesTab.test.tsx
+++ b/src/programs/courses-tab/CoursesTab.test.tsx
@@ -36,6 +36,14 @@ describe('<CoursesTab />', () => {
     expect(screen.getByText('2025')).toBeInTheDocument();
   });
 
+  it('hides course management actions in read-only mode', () => {
+    const program = mockProgram({ courses: [mockCourse()] });
+    render(<CoursesTab program={program} programId={programId} canManage={false} />);
+
+    expect(screen.queryByRole('button', { name: /Add Course/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Remove/i })).not.toBeInTheDocument();
+  });
+
   it('opens AddCourseModal when "Add Course" is clicked', () => {
     const program = mockProgram({ courses: [] });
     render(<CoursesTab program={program} programId={programId} />);

--- a/src/programs/courses-tab/CoursesTab.tsx
+++ b/src/programs/courses-tab/CoursesTab.tsx
@@ -26,9 +26,10 @@ const messages = defineMessages({
 interface CoursesTabProps {
   program: Program;
   programId: string;
+  canManage?: boolean;
 }
 
-const CoursesTab: React.FC<CoursesTabProps> = ({ program, programId }) => {
+const CoursesTab: React.FC<CoursesTabProps> = ({ program, programId, canManage = true }) => {
   const intl = useIntl();
   const [isModalOpen, openModal, closeModal] = useToggle(false);
   const [confirmCourseId, setConfirmCourseId] = useState<string | null>(null);
@@ -47,14 +48,16 @@ const CoursesTab: React.FC<CoursesTabProps> = ({ program, programId }) => {
           <h3 className="mb-1">{intl.formatMessage(messages.sectionTitle)}</h3>
           <p className="text-muted small mb-0">{intl.formatMessage(messages.sectionSubtitle)}</p>
         </div>
-        <Button
-          variant="outline-primary"
-          iconBefore={Add}
-          size="sm"
-          onClick={openModal}
-        >
-          {intl.formatMessage(messages.addCourseBtn)}
-        </Button>
+        {canManage && (
+          <Button
+            variant="outline-primary"
+            iconBefore={Add}
+            size="sm"
+            onClick={openModal}
+          >
+            {intl.formatMessage(messages.addCourseBtn)}
+          </Button>
+        )}
       </div>
 
       {/* Course list */}
@@ -96,43 +99,49 @@ const CoursesTab: React.FC<CoursesTabProps> = ({ program, programId }) => {
                 </Stack>
               </div>
 
-              <Button
-                variant="outline-danger"
-                size="sm"
-                onClick={() => setConfirmCourseId(course.id)}
-                disabled={confirmCourseId !== null}
-              >
-                {intl.formatMessage(messages.removeBtn)}
-              </Button>
+              {canManage && (
+                <Button
+                  variant="outline-danger"
+                  size="sm"
+                  onClick={() => setConfirmCourseId(course.id)}
+                  disabled={confirmCourseId !== null}
+                >
+                  {intl.formatMessage(messages.removeBtn)}
+                </Button>
+              )}
             </div>
           ))}
         </div>
       )}
 
-      <AddCourseModal
-        isOpen={isModalOpen}
-        onClose={closeModal}
-        programId={programId}
-        alreadyAddedIds={courseIds}
-      />
+      {canManage && (
+        <>
+          <AddCourseModal
+            isOpen={isModalOpen}
+            onClose={closeModal}
+            programId={programId}
+            alreadyAddedIds={courseIds}
+          />
 
-      <DeleteModal
-        isOpen={!!confirmCourseId}
-        close={() => setConfirmCourseId(null)}
-        title={intl.formatMessage(messages.confirmRemoveTitle)}
-        description={(
-          <>
-            <strong>{confirmCourse?.displayName}</strong>
-            <br />
-            {intl.formatMessage(messages.confirmRemoveDesc)}
-          </>
-        )}
-        btnLabel={intl.formatMessage(messages.confirmRemoveBtn)}
-        onDeleteSubmit={async () => {
-          await removeCourse.mutateAsync({ programId, courseId: confirmCourseId! });
-          setConfirmCourseId(null);
-        }}
-      />
+          <DeleteModal
+            isOpen={!!confirmCourseId}
+            close={() => setConfirmCourseId(null)}
+            title={intl.formatMessage(messages.confirmRemoveTitle)}
+            description={(
+              <>
+                <strong>{confirmCourse?.displayName}</strong>
+                <br />
+                {intl.formatMessage(messages.confirmRemoveDesc)}
+              </>
+            )}
+            btnLabel={intl.formatMessage(messages.confirmRemoveBtn)}
+            onDeleteSubmit={async () => {
+              await removeCourse.mutateAsync({ programId, courseId: confirmCourseId! });
+              setConfirmCourseId(null);
+            }}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/src/programs/data/api.ts
+++ b/src/programs/data/api.ts
@@ -8,7 +8,6 @@ import type {
   CityOption,
   Course,
   CreateProgramInput,
-  FbrUserProfile,
   Instructor,
   Learner,
   PaginatedCourses,
@@ -18,20 +17,10 @@ import type {
   ProgramDetailResponse,
 } from './types';
 
-const getProgramsBaseUrl = () => `${getConfig().STUDIO_BASE_URL}/fbr/api/programs`;
-export const getCurrentFbrProfileUrl = () => `${getConfig().LMS_BASE_URL}/fbr/api/biodata/v1/users/me/`;
-export const getFbrCitiesUrl = () => `${getConfig().LMS_BASE_URL}/fbr/api/biodata/v1/users/cities/`;
+export { getCurrentFbrProfile, getCurrentFbrProfileUrl } from '@src/fbr-access/api';
 
-export const getCurrentFbrProfile = async (): Promise<FbrUserProfile> => {
-  const { data } = await getAuthenticatedHttpClient().get(getCurrentFbrProfileUrl());
-  return {
-    id: data.id,
-    fullName: data.full_name,
-    email: data.email,
-    roles: Array.isArray(data.roles) ? data.roles : [],
-    city: data.city ?? null,
-  };
-};
+const getProgramsBaseUrl = () => `${getConfig().STUDIO_BASE_URL}/fbr/api/programs`;
+export const getFbrCitiesUrl = () => `${getConfig().LMS_BASE_URL}/fbr/api/biodata/v1/users/cities/`;
 
 export const getFbrCities = async (): Promise<CityOption[]> => {
   const { data } = await getAuthenticatedHttpClient().get(getFbrCitiesUrl());

--- a/src/programs/data/api.ts
+++ b/src/programs/data/api.ts
@@ -5,7 +5,10 @@ import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import type {
   Batch,
+  CityOption,
   Course,
+  CreateProgramInput,
+  FbrUserProfile,
   Instructor,
   Learner,
   PaginatedCourses,
@@ -16,6 +19,24 @@ import type {
 } from './types';
 
 const getProgramsBaseUrl = () => `${getConfig().STUDIO_BASE_URL}/fbr/api/programs`;
+export const getCurrentFbrProfileUrl = () => `${getConfig().LMS_BASE_URL}/fbr/api/biodata/v1/users/me/`;
+export const getFbrCitiesUrl = () => `${getConfig().LMS_BASE_URL}/fbr/api/biodata/v1/users/cities/`;
+
+export const getCurrentFbrProfile = async (): Promise<FbrUserProfile> => {
+  const { data } = await getAuthenticatedHttpClient().get(getCurrentFbrProfileUrl());
+  return {
+    id: data.id,
+    fullName: data.full_name,
+    email: data.email,
+    roles: Array.isArray(data.roles) ? data.roles : [],
+    city: data.city ?? null,
+  };
+};
+
+export const getFbrCities = async (): Promise<CityOption[]> => {
+  const { data } = await getAuthenticatedHttpClient().get(getFbrCitiesUrl());
+  return Array.isArray(data) ? data : [];
+};
 
 // ── Response → Course type transformation ────────────────────────────────────
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -78,12 +99,13 @@ export const getProgramDetail = async (programId: string): Promise<ProgramDetail
 };
 
 // ── Create — POST /fbr/api/programs/ ────────────────────────────────────────
-export const createProgram = async (input: Omit<Program, 'id'>): Promise<Program> => {
+export const createProgram = async (input: CreateProgramInput): Promise<Program> => {
   const payload = {
     name: input.displayName,
     organization: input.org,
     program_type: input.programType,
     batch: input.run,
+    ...(input.cityId !== undefined ? { city: input.cityId } : {}),
   };
   const { data } = await getAuthenticatedHttpClient().post(`${getProgramsBaseUrl()}/`, payload);
   return toProgram(data);

--- a/src/programs/data/apiHooks.ts
+++ b/src/programs/data/apiHooks.ts
@@ -1,9 +1,9 @@
 import {
   useQuery, useMutation, useQueryClient, keepPreviousData,
 } from '@tanstack/react-query';
+import { useCurrentFbrProfile } from '@src/fbr-access/apiHooks';
 import {
   getProgramsConfig,
-  getCurrentFbrProfile,
   getFbrCities,
   getPrograms,
   getProgramDetail,
@@ -32,12 +32,7 @@ import type { Program } from './types';
 import { getProgramCapabilities } from './permissions';
 
 export const useProgramAccess = () => {
-  const query = useQuery({
-    queryKey: ['currentFbrProfile'],
-    queryFn: getCurrentFbrProfile,
-    staleTime: 5 * 60 * 1000,
-    retry: false,
-  });
+  const query = useCurrentFbrProfile();
 
   return {
     ...query,

--- a/src/programs/data/apiHooks.ts
+++ b/src/programs/data/apiHooks.ts
@@ -3,6 +3,8 @@ import {
 } from '@tanstack/react-query';
 import {
   getProgramsConfig,
+  getCurrentFbrProfile,
+  getFbrCities,
   getPrograms,
   getProgramDetail,
   createProgram,
@@ -27,6 +29,29 @@ import {
   type GetLearnersParams,
 } from './api';
 import type { Program } from './types';
+import { getProgramCapabilities } from './permissions';
+
+export const useProgramAccess = () => {
+  const query = useQuery({
+    queryKey: ['currentFbrProfile'],
+    queryFn: getCurrentFbrProfile,
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+
+  return {
+    ...query,
+    profile: query.data,
+    capabilities: getProgramCapabilities(query.data?.roles),
+  };
+};
+
+export const useFbrCities = (enabled = true) => useQuery({
+  queryKey: ['fbrCities'],
+  queryFn: getFbrCities,
+  staleTime: 10 * 60 * 1000,
+  enabled,
+});
 
 export const useProgramsConfig = () => useQuery({
   queryKey: ['programsConfig'],
@@ -38,10 +63,10 @@ export const usePrograms = () => useQuery({
   queryFn: getPrograms,
 });
 
-export const useProgramDetail = (programId: string) => useQuery({
+export const useProgramDetail = (programId: string, enabled = true) => useQuery({
   queryKey: ['program', programId],
   queryFn: () => getProgramDetail(programId),
-  enabled: !!programId,
+  enabled: !!programId && enabled,
 });
 
 export const useCreateProgram = () => {

--- a/src/programs/data/permissions.test.ts
+++ b/src/programs/data/permissions.test.ts
@@ -1,0 +1,62 @@
+import { getProgramCapabilities } from './permissions';
+
+describe('getProgramCapabilities', () => {
+  it.each(['super_admin', 'middle_admin'] as const)(
+    'grants full program management to %s',
+    (role) => {
+      expect(getProgramCapabilities([role])).toEqual({
+        canAccessPrograms: true,
+        canCreateProgram: true,
+        canEditProgram: true,
+        canArchiveProgram: true,
+        canManageCourses: true,
+        canManageEnrollment: true,
+        canManageInstructors: true,
+        isReadOnly: false,
+      });
+    },
+  );
+
+  it('prevents Data Admins from creating or archiving programs', () => {
+    expect(getProgramCapabilities(['data_admin'])).toMatchObject({
+      canAccessPrograms: true,
+      canCreateProgram: false,
+      canEditProgram: true,
+      canArchiveProgram: false,
+      canManageCourses: true,
+      canManageEnrollment: true,
+      canManageInstructors: true,
+      isReadOnly: false,
+    });
+  });
+
+  it('gives instructors read-only access', () => {
+    expect(getProgramCapabilities(['instructor'])).toMatchObject({
+      canAccessPrograms: true,
+      canCreateProgram: false,
+      canEditProgram: false,
+      canManageCourses: false,
+      canManageEnrollment: false,
+      canManageInstructors: false,
+      isReadOnly: true,
+    });
+  });
+
+  it('denies program access to trainees', () => {
+    expect(getProgramCapabilities(['trainee'])).toMatchObject({
+      canAccessPrograms: false,
+      canCreateProgram: false,
+      canEditProgram: false,
+      isReadOnly: true,
+    });
+  });
+
+  it('denies program access when no FBR role is available', () => {
+    expect(getProgramCapabilities([])).toMatchObject({
+      canAccessPrograms: false,
+      canCreateProgram: false,
+      canEditProgram: false,
+      isReadOnly: true,
+    });
+  });
+});

--- a/src/programs/data/permissions.ts
+++ b/src/programs/data/permissions.ts
@@ -1,0 +1,36 @@
+import type { FbrRole, ProgramCapabilities } from './types';
+
+const NO_PROGRAM_ACCESS: ProgramCapabilities = {
+  canAccessPrograms: false,
+  canCreateProgram: false,
+  canEditProgram: false,
+  canArchiveProgram: false,
+  canManageCourses: false,
+  canManageEnrollment: false,
+  canManageInstructors: false,
+  isReadOnly: true,
+};
+
+export const getProgramCapabilities = (roles: FbrRole[] = []): ProgramCapabilities => {
+  const roleSet = new Set(roles);
+  const isSuperAdmin = roleSet.has('super_admin');
+  const isMiddleAdmin = roleSet.has('middle_admin');
+  const isDataAdmin = roleSet.has('data_admin');
+  const isInstructor = roleSet.has('instructor');
+  const isProgramAdmin = isSuperAdmin || isMiddleAdmin || isDataAdmin;
+
+  if (!isProgramAdmin && !isInstructor) {
+    return NO_PROGRAM_ACCESS;
+  }
+
+  return {
+    canAccessPrograms: true,
+    canCreateProgram: isSuperAdmin || isMiddleAdmin,
+    canEditProgram: isProgramAdmin,
+    canArchiveProgram: isSuperAdmin || isMiddleAdmin,
+    canManageCourses: isProgramAdmin,
+    canManageEnrollment: isProgramAdmin,
+    canManageInstructors: isProgramAdmin,
+    isReadOnly: !isProgramAdmin,
+  };
+};

--- a/src/programs/data/types.ts
+++ b/src/programs/data/types.ts
@@ -1,3 +1,5 @@
+export type { FbrRole, FbrUserProfile } from '@src/fbr-access/types';
+
 export interface Course {
   id: string;
   displayName: string;
@@ -58,24 +60,6 @@ export interface CreateProgramInput {
   programType: string;
   run: string;
   cityId?: number;
-}
-
-export type FbrRole =
-  | 'super_admin'
-  | 'middle_admin'
-  | 'data_admin'
-  | 'instructor'
-  | 'trainee';
-
-export interface FbrUserProfile {
-  id: number;
-  fullName: string;
-  email: string;
-  roles: FbrRole[];
-  city: {
-    id: number;
-    name: string;
-  } | null;
 }
 
 export interface ProgramCapabilities {

--- a/src/programs/data/types.ts
+++ b/src/programs/data/types.ts
@@ -47,6 +47,48 @@ export interface ProgramConfig {
   statuses: string[];
 }
 
+export interface CityOption {
+  id: number;
+  name: string;
+}
+
+export interface CreateProgramInput {
+  displayName: string;
+  org: string;
+  programType: string;
+  run: string;
+  cityId?: number;
+}
+
+export type FbrRole =
+  | 'super_admin'
+  | 'middle_admin'
+  | 'data_admin'
+  | 'instructor'
+  | 'trainee';
+
+export interface FbrUserProfile {
+  id: number;
+  fullName: string;
+  email: string;
+  roles: FbrRole[];
+  city: {
+    id: number;
+    name: string;
+  } | null;
+}
+
+export interface ProgramCapabilities {
+  canAccessPrograms: boolean;
+  canCreateProgram: boolean;
+  canEditProgram: boolean;
+  canArchiveProgram: boolean;
+  canManageCourses: boolean;
+  canManageEnrollment: boolean;
+  canManageInstructors: boolean;
+  isReadOnly: boolean;
+}
+
 export interface ProgramDetailResponse {
   program: Program;
   /** All target audiences available system-wide — used for the dropdown options. */

--- a/src/programs/enrollment-tab/EnrollmentTab.test.tsx
+++ b/src/programs/enrollment-tab/EnrollmentTab.test.tsx
@@ -36,6 +36,14 @@ describe('<EnrollmentTab />', () => {
     expect(screen.getByText('alice@example.com')).toBeInTheDocument();
   });
 
+  it('hides enrollment management actions in read-only mode', () => {
+    render(<EnrollmentTab programId={programId} canManage={false} />);
+
+    expect(screen.queryByRole('button', { name: /Enroll Learner/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Enroll Batch/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Unenroll/i })).not.toBeInTheDocument();
+  });
+
   it('shows empty state message when no learners enrolled', () => {
     mockUseProgramEnrollments.mockReturnValue({
       data: mockPaginatedLearners([], { count: 0 }),

--- a/src/programs/enrollment-tab/EnrollmentTab.tsx
+++ b/src/programs/enrollment-tab/EnrollmentTab.tsx
@@ -40,9 +40,10 @@ const messages = defineMessages({
 
 interface EnrollmentTabProps {
   programId: string;
+  canManage?: boolean;
 }
 
-const EnrollmentTab: React.FC<EnrollmentTabProps> = ({ programId }) => {
+const EnrollmentTab: React.FC<EnrollmentTabProps> = ({ programId, canManage = true }) => {
   const intl = useIntl();
   const [isModalOpen, openModal, closeModal] = useToggle(false);
   const [isBatchModalOpen, openBatchModal, closeBatchModal] = useToggle(false);
@@ -71,24 +72,26 @@ const EnrollmentTab: React.FC<EnrollmentTabProps> = ({ programId }) => {
           <h3 className="mb-1">{intl.formatMessage(messages.sectionTitle)}</h3>
           <p className="text-muted small mb-0">{intl.formatMessage(messages.sectionSubtitle)}</p>
         </div>
-        <Stack direction="horizontal" gap={2}>
-          <Button
-            variant="outline-primary"
-            iconBefore={Add}
-            size="sm"
-            onClick={openBatchModal}
-          >
-            {intl.formatMessage(messages.enrollBatchBtn)}
-          </Button>
-          <Button
-            variant="outline-primary"
-            iconBefore={Add}
-            size="sm"
-            onClick={openModal}
-          >
-            {intl.formatMessage(messages.enrollLearnerBtn)}
-          </Button>
-        </Stack>
+        {canManage && (
+          <Stack direction="horizontal" gap={2}>
+            <Button
+              variant="outline-primary"
+              iconBefore={Add}
+              size="sm"
+              onClick={openBatchModal}
+            >
+              {intl.formatMessage(messages.enrollBatchBtn)}
+            </Button>
+            <Button
+              variant="outline-primary"
+              iconBefore={Add}
+              size="sm"
+              onClick={openModal}
+            >
+              {intl.formatMessage(messages.enrollLearnerBtn)}
+            </Button>
+          </Stack>
+        )}
       </div>
 
       <div className="mb-3">
@@ -144,14 +147,16 @@ const EnrollmentTab: React.FC<EnrollmentTabProps> = ({ programId }) => {
                 <Badge variant="light">{learner.email}</Badge>
               </Stack>
             </div>
-            <Button
-              variant="outline-danger"
-              size="sm"
-              onClick={() => setConfirmUnenrollUsername(learner.username)}
-              disabled={confirmUnenrollUsername !== null}
-            >
-              {intl.formatMessage(messages.unenrollBtn)}
-            </Button>
+            {canManage && (
+              <Button
+                variant="outline-danger"
+                size="sm"
+                onClick={() => setConfirmUnenrollUsername(learner.username)}
+                disabled={confirmUnenrollUsername !== null}
+              >
+                {intl.formatMessage(messages.unenrollBtn)}
+              </Button>
+            )}
           </div>
         ))}
       </div>
@@ -172,39 +177,43 @@ const EnrollmentTab: React.FC<EnrollmentTabProps> = ({ programId }) => {
         />
       )}
 
-      <AddLearnerModal
-        isOpen={isModalOpen}
-        onClose={closeModal}
-        programId={programId}
-        alreadyEnrolledIds={enrolledIds}
-      />
+      {canManage && (
+        <>
+          <AddLearnerModal
+            isOpen={isModalOpen}
+            onClose={closeModal}
+            programId={programId}
+            alreadyEnrolledIds={enrolledIds}
+          />
 
-      <EnrollBatchModal
-        isOpen={isBatchModalOpen}
-        onClose={closeBatchModal}
-        programId={programId}
-        alreadyEnrolledIds={enrolledIds}
-      />
+          <EnrollBatchModal
+            isOpen={isBatchModalOpen}
+            onClose={closeBatchModal}
+            programId={programId}
+            alreadyEnrolledIds={enrolledIds}
+          />
 
-      <DeleteModal
-        isOpen={!!confirmUnenrollUsername}
-        close={() => setConfirmUnenrollUsername(null)}
-        title={intl.formatMessage(messages.confirmUnenrollTitle)}
-        description={(
-          <>
-            <strong>{confirmLearner?.name ?? confirmUnenrollUsername}</strong>
-            <br />
-            {intl.formatMessage(messages.confirmUnenrollDesc)}
-            {' '}
-            <strong>{intl.formatMessage(messages.confirmUnenrollWarning)}</strong>
-          </>
-        )}
-        btnLabel={intl.formatMessage(messages.confirmUnenrollBtn)}
-        onDeleteSubmit={async () => {
-          await unenrollLearner.mutateAsync({ programId, username: confirmUnenrollUsername! });
-          setConfirmUnenrollUsername(null);
-        }}
-      />
+          <DeleteModal
+            isOpen={!!confirmUnenrollUsername}
+            close={() => setConfirmUnenrollUsername(null)}
+            title={intl.formatMessage(messages.confirmUnenrollTitle)}
+            description={(
+              <>
+                <strong>{confirmLearner?.name ?? confirmUnenrollUsername}</strong>
+                <br />
+                {intl.formatMessage(messages.confirmUnenrollDesc)}
+                {' '}
+                <strong>{intl.formatMessage(messages.confirmUnenrollWarning)}</strong>
+              </>
+            )}
+            btnLabel={intl.formatMessage(messages.confirmUnenrollBtn)}
+            onDeleteSubmit={async () => {
+              await unenrollLearner.mutateAsync({ programId, username: confirmUnenrollUsername! });
+              setConfirmUnenrollUsername(null);
+            }}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/src/programs/instructors-tab/InstructorsTab.test.tsx
+++ b/src/programs/instructors-tab/InstructorsTab.test.tsx
@@ -52,6 +52,18 @@ describe('<InstructorsTab />', () => {
     expect(screen.getByText('smith@example.com')).toBeInTheDocument();
   });
 
+  it('hides instructor management actions in read-only mode', async () => {
+    const course = mockCourse({ id: 'course-v1:Org+X+2025' });
+    mockUseCourseTeam.mockReturnValue({ data: [mockInstructor()], isLoading: false });
+    const program = mockProgram({ courses: [course] });
+
+    render(<InstructorsTab program={program} canManage={false} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: course.id } });
+
+    expect(screen.queryByRole('button', { name: /Add Instructor/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Remove/i })).not.toBeInTheDocument();
+  });
+
   it('shows role badge for instructor', async () => {
     const course = mockCourse({ id: 'course-v1:Org+X+2025', displayName: 'CS 101' });
     const instructor = mockInstructor({ role: 'staff' });

--- a/src/programs/instructors-tab/InstructorsTab.tsx
+++ b/src/programs/instructors-tab/InstructorsTab.tsx
@@ -33,9 +33,10 @@ const messages = defineMessages({
 
 interface InstructorsTabProps {
   program: Program;
+  canManage?: boolean;
 }
 
-const InstructorsTab: React.FC<InstructorsTabProps> = ({ program }) => {
+const InstructorsTab: React.FC<InstructorsTabProps> = ({ program, canManage = true }) => {
   const intl = useIntl();
   const courses = program.courses ?? [];
 
@@ -60,15 +61,17 @@ const InstructorsTab: React.FC<InstructorsTabProps> = ({ program }) => {
           <h3 className="mb-1">{intl.formatMessage(messages.sectionTitle)}</h3>
           <p className="text-muted small mb-0">{intl.formatMessage(messages.sectionSubtitle)}</p>
         </div>
-        <Button
-          variant="outline-primary"
-          iconBefore={Add}
-          size="sm"
-          onClick={openModal}
-          disabled={!selectedCourseId}
-        >
-          {intl.formatMessage(messages.addInstructorBtn)}
-        </Button>
+        {canManage && (
+          <Button
+            variant="outline-primary"
+            iconBefore={Add}
+            size="sm"
+            onClick={openModal}
+            disabled={!selectedCourseId}
+          >
+            {intl.formatMessage(messages.addInstructorBtn)}
+          </Button>
+        )}
       </div>
 
       {courses.length === 0 ? (
@@ -136,14 +139,16 @@ const InstructorsTab: React.FC<InstructorsTabProps> = ({ program }) => {
                       {instructor.role && <Badge variant="secondary">{instructor.role}</Badge>}
                     </Stack>
                   </div>
-                  <Button
-                    variant="outline-danger"
-                    size="sm"
-                    onClick={() => setConfirmEmail(instructor.email)}
-                    disabled={confirmEmail !== null}
-                  >
-                    {intl.formatMessage(messages.removeBtn)}
-                  </Button>
+                  {canManage && (
+                    <Button
+                      variant="outline-danger"
+                      size="sm"
+                      onClick={() => setConfirmEmail(instructor.email)}
+                      disabled={confirmEmail !== null}
+                    >
+                      {intl.formatMessage(messages.removeBtn)}
+                    </Button>
+                  )}
                 </div>
               ))}
             </div>
@@ -151,31 +156,35 @@ const InstructorsTab: React.FC<InstructorsTabProps> = ({ program }) => {
         </>
       )}
 
-      <AddInstructorModal
-        isOpen={isModalOpen}
-        onClose={closeModal}
-        courseId={selectedCourseId}
-        courseName={selectedCourse?.displayName ?? ''}
-        alreadyAddedEmails={teamEmails}
-      />
+      {canManage && (
+        <>
+          <AddInstructorModal
+            isOpen={isModalOpen}
+            onClose={closeModal}
+            courseId={selectedCourseId}
+            courseName={selectedCourse?.displayName ?? ''}
+            alreadyAddedEmails={teamEmails}
+          />
 
-      <DeleteModal
-        isOpen={!!confirmEmail}
-        close={() => setConfirmEmail(null)}
-        title={intl.formatMessage(messages.confirmRemoveTitle)}
-        description={(
-          <>
-            <strong>{confirmEmail}</strong>
-            <br />
-            {intl.formatMessage(messages.confirmRemoveDesc)}
-          </>
-        )}
-        btnLabel={intl.formatMessage(messages.confirmRemoveBtn)}
-        onDeleteSubmit={async () => {
-          await removeInstructor.mutateAsync({ courseId: selectedCourseId, email: confirmEmail! });
-          setConfirmEmail(null);
-        }}
-      />
+          <DeleteModal
+            isOpen={!!confirmEmail}
+            close={() => setConfirmEmail(null)}
+            title={intl.formatMessage(messages.confirmRemoveTitle)}
+            description={(
+              <>
+                <strong>{confirmEmail}</strong>
+                <br />
+                {intl.formatMessage(messages.confirmRemoveDesc)}
+              </>
+            )}
+            btnLabel={intl.formatMessage(messages.confirmRemoveBtn)}
+            onDeleteSubmit={async () => {
+              await removeInstructor.mutateAsync({ courseId: selectedCourseId, email: confirmEmail! });
+              setConfirmEmail(null);
+            }}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/src/studio-home/StudioHome.test.tsx
+++ b/src/studio-home/StudioHome.test.tsx
@@ -12,6 +12,7 @@ import { RequestStatus } from '../data/constants';
 import { COURSE_CREATOR_STATES } from '../constants';
 import studioHomeMock from './__mocks__/studioHomeMock';
 import { getStudioHomeApiUrl } from './data/api';
+import { getCurrentFbrProfileUrl } from '../programs/data/api';
 import { StudioHome } from '.';
 
 const {
@@ -59,6 +60,13 @@ describe('<StudioHome />', () => {
     beforeEach(async () => {
       const mocks = initializeMocks();
       mocks.axiosMock.onGet(getStudioHomeApiUrl()).reply(200, studioHomeMock);
+      mocks.axiosMock.onGet(getCurrentFbrProfileUrl()).reply(200, {
+        id: 1,
+        full_name: 'Super Admin',
+        email: 'admin@example.com',
+        roles: ['super_admin'],
+        city: null,
+      });
       mockUseSelector.mockReturnValue(studioHomeMock);
     });
 
@@ -89,6 +97,33 @@ describe('<StudioHome />', () => {
       render(<StudioHome />, { path: '/home' });
       const header = getHeaderElement();
       within(header).getByRole('button', { name: 'New course' }); // will error if not found
+    });
+
+    it('shows New program for Super Admins', async () => {
+      render(<StudioHome />, { path: '/home' });
+
+      await waitFor(() => {
+        expect(within(getHeaderElement()).getByRole('button', { name: 'New program' })).toBeInTheDocument();
+      });
+    });
+
+    it('hides New program for Data Admins', async () => {
+      const mocks = initializeMocks();
+      mocks.axiosMock.onGet(getStudioHomeApiUrl()).reply(200, studioHomeMock);
+      mocks.axiosMock.onGet(getCurrentFbrProfileUrl()).reply(200, {
+        id: 2,
+        full_name: 'Data Admin',
+        email: 'data@example.com',
+        roles: ['data_admin'],
+        city: { id: 1, name: 'Karachi' },
+      });
+      mockUseSelector.mockReturnValue(studioHomeMock);
+
+      render(<StudioHome />, { path: '/home' });
+
+      await waitFor(() => {
+        expect(within(getHeaderElement()).queryByRole('button', { name: 'New program' })).not.toBeInTheDocument();
+      });
     });
 
     it('should show verify email layout if user inactive', async () => {

--- a/src/studio-home/StudioHome.tsx
+++ b/src/studio-home/StudioHome.tsx
@@ -25,11 +25,16 @@ import CreateNewProgramForm from './create-new-program-form';
 import messages from './messages';
 import { useStudioHome } from './hooks';
 import AlertMessage from '../generic/alert-message';
+import { useProgramAccess } from '../programs/data/apiHooks';
 
 const StudioHome = () => {
   const intl = useIntl();
   const location = useLocation();
   const navigate = useNavigate();
+  const {
+    capabilities: programCapabilities,
+    isLoading: isProgramAccessLoading,
+  } = useProgramAccess();
 
   const {
     isLoadingPage,
@@ -74,17 +79,19 @@ const StudioHome = () => {
       );
     }
 
-    headerButtons.push(
-      <Button
-        variant="outline-primary"
-        iconBefore={AddIcon}
-        size="sm"
-        disabled={showNewProgramContainer}
-        onClick={() => setShowNewProgramContainer(true)}
-      >
-        {intl.formatMessage(messages.addNewProgramBtnText)}
-      </Button>,
-    );
+    if (programCapabilities.canCreateProgram) {
+      headerButtons.push(
+        <Button
+          variant="outline-primary"
+          iconBefore={AddIcon}
+          size="sm"
+          disabled={showNewProgramContainer}
+          onClick={() => setShowNewProgramContainer(true)}
+        >
+          {intl.formatMessage(messages.addNewProgramBtnText)}
+        </Button>,
+      );
+    }
 
     if (hasAbilityToCreateNewCourse) {
       headerButtons.push(
@@ -122,7 +129,13 @@ const StudioHome = () => {
     }
 
     return headerButtons;
-  }, [location, userIsActive, isFailedLoadingPage]);
+  }, [
+    location,
+    userIsActive,
+    isFailedLoadingPage,
+    programCapabilities.canCreateProgram,
+    showNewProgramContainer,
+  ]);
 
   const headerButtons = userIsActive ? getHeaderButtons() : [];
   if (isLoadingPage && !isFiltered) {
@@ -159,7 +172,7 @@ const StudioHome = () => {
             {showNewCourseContainer && (
               <CreateNewCourseForm handleOnClickCancel={() => setShowNewCourseContainer(false)} />
             )}
-            {showNewProgramContainer && (
+            {showNewProgramContainer && programCapabilities.canCreateProgram && (
               <CreateNewProgramForm handleOnClickCancel={() => setShowNewProgramContainer(false)} />
             )}
             {isShowOrganizationDropdown && <OrganizationSection />}
@@ -170,6 +183,8 @@ const StudioHome = () => {
               librariesV1Enabled={librariesV1Enabled}
               librariesV2Enabled={librariesV2Enabled}
               showNewProgramContainer={showNewProgramContainer}
+              canAccessPrograms={programCapabilities.canAccessPrograms}
+              isProgramAccessLoading={isProgramAccessLoading}
             />
           </section>
         </Layout.Element>

--- a/src/studio-home/create-new-program-form/CreateNewProgramForm.test.jsx
+++ b/src/studio-home/create-new-program-form/CreateNewProgramForm.test.jsx
@@ -1,0 +1,117 @@
+import {
+  fireEvent,
+  initializeMocks,
+  render,
+  screen,
+  waitFor,
+} from '@src/testUtils';
+import CreateNewProgramForm from '.';
+
+const mockCreateProgram = jest.fn();
+const mockUseProgramAccess = jest.fn();
+const mockUseFbrCities = jest.fn();
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../programs/data/apiHooks', () => ({
+  useProgramsConfig: () => ({
+    data: {
+      orgs: [{ id: 1, name: 'FBR Academy', shortName: 'FBR' }],
+      programTypes: [{ id: 1, name: 'STP', slug: 'stp' }],
+    },
+  }),
+  useProgramAccess: () => mockUseProgramAccess(),
+  useFbrCities: (...args) => mockUseFbrCities(...args),
+  useCreateProgram: () => ({
+    mutateAsync: mockCreateProgram,
+    isPending: false,
+  }),
+}));
+
+const fillRequiredFields = () => {
+  fireEvent.change(screen.getByLabelText('Program name'), {
+    target: { value: 'New Program' },
+  });
+  fireEvent.change(screen.getByLabelText(/Organization/), {
+    target: { value: 'FBR' },
+  });
+  fireEvent.change(screen.getByLabelText(/Program type/), {
+    target: { value: 'stp' },
+  });
+  fireEvent.change(screen.getByLabelText(/Program run/), {
+    target: { value: '2026' },
+  });
+};
+
+describe('<CreateNewProgramForm />', () => {
+  beforeEach(() => {
+    initializeMocks();
+    mockCreateProgram.mockResolvedValue({ id: 'program-v1:FBR+STP+2026' });
+    mockUseFbrCities.mockReturnValue({
+      data: [
+        { id: 1, name: 'Karachi' },
+        { id: 2, name: 'Lahore' },
+      ],
+    });
+    mockNavigate.mockReset();
+  });
+
+  it('shows cities and submits the selected city for Super Admins', async () => {
+    mockUseProgramAccess.mockReturnValue({
+      profile: { roles: ['super_admin'] },
+    });
+
+    render(<CreateNewProgramForm handleOnClickCancel={jest.fn()} />);
+    fillRequiredFields();
+    fireEvent.change(screen.getByLabelText(/City/), {
+      target: { value: '2' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(mockCreateProgram).toHaveBeenCalledWith({
+      displayName: 'New Program',
+      org: 'FBR',
+      programType: 'stp',
+      run: '2026',
+      cityId: 2,
+    }));
+    expect(mockUseFbrCities).toHaveBeenCalledWith(true);
+  });
+
+  it('requires a city for Super Admins', async () => {
+    mockUseProgramAccess.mockReturnValue({
+      profile: { roles: ['super_admin'] },
+    });
+
+    render(<CreateNewProgramForm handleOnClickCancel={jest.fn()} />);
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(await screen.findByText('City is required.')).toBeInTheDocument();
+    expect(mockCreateProgram).not.toHaveBeenCalled();
+  });
+
+  it('does not show or submit city for Middle Admins', async () => {
+    mockUseProgramAccess.mockReturnValue({
+      profile: { roles: ['middle_admin'] },
+    });
+
+    render(<CreateNewProgramForm handleOnClickCancel={jest.fn()} />);
+    fillRequiredFields();
+
+    expect(screen.queryByLabelText(/City/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(mockCreateProgram).toHaveBeenCalledWith({
+      displayName: 'New Program',
+      org: 'FBR',
+      programType: 'stp',
+      run: '2026',
+    }));
+    expect(mockUseFbrCities).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/studio-home/create-new-program-form/index.jsx
+++ b/src/studio-home/create-new-program-form/index.jsx
@@ -10,13 +10,21 @@ import {
 } from '@openedx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { useNavigate } from 'react-router-dom';
-import { useProgramsConfig, useCreateProgram } from '../../programs/data/apiHooks';
+import {
+  useCreateProgram,
+  useFbrCities,
+  useProgramAccess,
+  useProgramsConfig,
+} from '../../programs/data/apiHooks';
 import messages from './messages';
 
 const CreateNewProgramForm = ({ handleOnClickCancel }) => {
   const intl = useIntl();
   const navigate = useNavigate();
   const { data: config } = useProgramsConfig();
+  const { profile } = useProgramAccess();
+  const isSuperAdmin = profile?.roles?.includes('super_admin') ?? false;
+  const { data: cities = [] } = useFbrCities(isSuperAdmin);
   const { mutateAsync: createProgram, isPending } = useCreateProgram();
 
   const orgs = config?.orgs ?? [];
@@ -27,12 +35,19 @@ const CreateNewProgramForm = ({ handleOnClickCancel }) => {
     org: Yup.string().required(intl.formatMessage(messages.orgRequired)),
     programType: Yup.string().required(intl.formatMessage(messages.programTypeRequired)),
     run: Yup.string().trim().required(intl.formatMessage(messages.programRunRequired)),
+    cityId: isSuperAdmin
+      ? Yup.string().required(intl.formatMessage(messages.cityRequired))
+      : Yup.string().notRequired(),
   });
 
   const handleSubmit = async (values, { setStatus }) => {
     try {
       const created = await createProgram({
-        ...values, targetAudience: '', status: 'draft', isFeatured: false,
+        displayName: values.displayName,
+        org: values.org,
+        programType: values.programType,
+        run: values.run,
+        ...(isSuperAdmin ? { cityId: Number(values.cityId) } : {}),
       });
       navigate(`/programs/${created.id}`);
     } catch (e) {
@@ -56,6 +71,7 @@ const CreateNewProgramForm = ({ handleOnClickCancel }) => {
           org: '',
           programType: '',
           run: '',
+          cityId: '',
         }}
         validationSchema={validationSchema}
         onSubmit={handleSubmit}
@@ -109,6 +125,30 @@ const CreateNewProgramForm = ({ handleOnClickCancel }) => {
                 <Form.Control.Feedback type="invalid">{errors.org}</Form.Control.Feedback>
               )}
             </Form.Group>
+
+            {isSuperAdmin && (
+              <Form.Group isInvalid={touched.cityId && !!errors.cityId}>
+                <Form.Label>
+                  {intl.formatMessage(messages.cityLabel)}
+                  <span className="text-muted small ml-1">(non-editable after creation)</span>
+                </Form.Label>
+                <Form.Control
+                  as="select"
+                  name="cityId"
+                  value={values.cityId}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                >
+                  <option value="">{intl.formatMessage(messages.selectPlaceholder)}</option>
+                  {cities.map((city) => (
+                    <option key={city.id} value={city.id}>{city.name}</option>
+                  ))}
+                </Form.Control>
+                {touched.cityId && errors.cityId && (
+                  <Form.Control.Feedback type="invalid">{errors.cityId}</Form.Control.Feedback>
+                )}
+              </Form.Group>
+            )}
 
             {/* Program Type — non-editable after creation */}
             <Form.Group isInvalid={touched.programType && !!errors.programType}>

--- a/src/studio-home/create-new-program-form/messages.js
+++ b/src/studio-home/create-new-program-form/messages.js
@@ -45,6 +45,14 @@ const messages = defineMessages({
     id: 'course-authoring.studio-home.new-program.run.required',
     defaultMessage: 'Program run is required.',
   },
+  cityLabel: {
+    id: 'course-authoring.studio-home.new-program.city.label',
+    defaultMessage: 'City',
+  },
+  cityRequired: {
+    id: 'course-authoring.studio-home.new-program.city.required',
+    defaultMessage: 'City is required.',
+  },
   targetAudienceLabel: {
     id: 'course-authoring.studio-home.new-program.audience.label',
     defaultMessage: 'Target audience',

--- a/src/studio-home/tabs-section/TabsSection.test.tsx
+++ b/src/studio-home/tabs-section/TabsSection.test.tsx
@@ -43,6 +43,8 @@ const tabSectionComponent = (overrideProps) => (
     isShowProcessing
     librariesV1Enabled
     librariesV2Enabled
+    canAccessPrograms
+    isProgramAccessLoading={false}
     {...overrideProps}
   />
 );
@@ -90,10 +92,21 @@ describe('<TabsSection />', () => {
     await executeThunk(fetchStudioHomeData(), store.dispatch);
 
     expect(screen.getByRole('tab', { name: tabMessages.coursesTabTitle.defaultMessage })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: tabMessages.programsTabTitle.defaultMessage })).toBeInTheDocument();
 
     expect(screen.getByRole('tab', { name: librariesBetaTabTitle })).toBeInTheDocument();
 
     expect(screen.getByRole('tab', { name: tabMessages.legacyLibrariesTabTitle.defaultMessage })).toBeInTheDocument();
+  });
+
+  it('does not render the programs tab without program access', async () => {
+    const data: any = generateGetStudioHomeDataApiResponse();
+
+    render({ canAccessPrograms: false });
+    axiosMock.onGet(getStudioHomeApiUrl()).reply(200, data);
+    await executeThunk(fetchStudioHomeData(), store.dispatch);
+
+    expect(screen.queryByRole('tab', { name: tabMessages.programsTabTitle.defaultMessage })).not.toBeInTheDocument();
   });
 
   it('should render only 1 library tab when libraries-v2 disabled', async () => {

--- a/src/studio-home/tabs-section/courses-tab/courses-filters/index.jsx
+++ b/src/studio-home/tabs-section/courses-tab/courses-filters/index.jsx
@@ -25,6 +25,7 @@ const CoursesFilters = ({
   locationValue,
   onSubmitSearchField,
   isLoading,
+  showLifecycleFilter,
 }) => {
   const studioHomeCoursesParams = useSelector(getStudioHomeCoursesParams);
   const {
@@ -128,7 +129,9 @@ const CoursesFilters = ({
 
       <CoursesTypesFilterMenu onItemMenuSelected={handleMenuFilterItemSelected} />
       <CoursesOrderFilterMenu onItemMenuSelected={handleMenuFilterItemSelected} />
-      <CoursesLifecycleFilterMenu onItemMenuSelected={handleLifecycleFilterSelected} />
+      {showLifecycleFilter && (
+        <CoursesLifecycleFilterMenu onItemMenuSelected={handleLifecycleFilterSelected} />
+      )}
     </div>
   );
 };
@@ -137,6 +140,7 @@ CoursesFilters.defaultProps = {
   locationValue: '',
   onSubmitSearchField: () => {},
   isLoading: false,
+  showLifecycleFilter: false,
 };
 
 CoursesFilters.propTypes = {
@@ -144,6 +148,7 @@ CoursesFilters.propTypes = {
   locationValue: PropTypes.string,
   onSubmitSearchField: PropTypes.func,
   isLoading: PropTypes.bool,
+  showLifecycleFilter: PropTypes.bool,
 };
 
 export default CoursesFilters;

--- a/src/studio-home/tabs-section/courses-tab/index.tsx
+++ b/src/studio-home/tabs-section/courses-tab/index.tsx
@@ -68,7 +68,13 @@ const CoursesTab: React.FC<Props> = ({
   const { currentPage, isFiltered, lifecycleFilter } = studioHomeCoursesParams;
 
   const courseKeys = coursesDataItems?.map((c) => c.courseKey) ?? [];
-  const { data: bulkLifecycleStates = {}, isLoading: isLifecycleLoading } = useBulkCourseAggregateStates(courseKeys);
+  const {
+    data: bulkLifecycleStates = {},
+    isLoading: isLifecycleLoading,
+    isAccessPending: isLifecycleAccessPending,
+    isAccessDenied: isLifecycleAccessDenied,
+  } = useBulkCourseAggregateStates(courseKeys);
+  const canAccessLifecycle = !isLifecycleAccessPending && !isLifecycleAccessDenied;
   const hasAbilityToCreateCourse = courseCreatorStatus === COURSE_CREATOR_STATES.granted;
   const showCollapsible = [
     COURSE_CREATOR_STATES.denied,
@@ -103,7 +109,8 @@ const CoursesTab: React.FC<Props> = ({
 
   const isNotFilteringCourses = !isFiltered && !isLoading;
   const hasCourses = coursesDataItems?.length > 0;
-  const visibleCoursesCount = lifecycleFilter
+  const activeLifecycleFilter = canAccessLifecycle ? lifecycleFilter : undefined;
+  const visibleCoursesCount = activeLifecycleFilter
     ? (coursesDataItems?.filter(({ courseKey }) => bulkLifecycleStates[courseKey] === lifecycleFilter).length ?? 0)
     : (coursesDataItems?.length ?? 0);
   const hasVisibleCourses = visibleCoursesCount > 0;
@@ -131,7 +138,12 @@ const CoursesTab: React.FC<Props> = ({
       <div className="courses-tab-container">
         <div className="d-flex flex-row align-items-center justify-content-between my-4">
           {isShowProcessing && <ProcessingCourses />}
-          <CoursesFilters dispatch={dispatch} locationValue={locationValue} isLoading={isLoading} />
+          <CoursesFilters
+            dispatch={dispatch}
+            locationValue={locationValue}
+            isLoading={isLoading}
+            showLifecycleFilter={canAccessLifecycle}
+          />
           <p data-testid="pagination-info" className="my-0">
             {intl.formatMessage(messages.coursesPaginationInfo, {
               length: coursesDataItems.length,
@@ -162,8 +174,10 @@ const CoursesTab: React.FC<Props> = ({
                   number={number}
                   run={run}
                   url={url}
-                  lifecycleState={bulkLifecycleStates[courseKey] as LifecycleState}
-                  lifecycleFilter={lifecycleFilter}
+                  lifecycleState={canAccessLifecycle
+                    ? bulkLifecycleStates[courseKey] as LifecycleState
+                    : undefined}
+                  lifecycleFilter={activeLifecycleFilter}
                 />
               ),
             )}

--- a/src/studio-home/tabs-section/index.tsx
+++ b/src/studio-home/tabs-section/index.tsx
@@ -27,6 +27,8 @@ const TabsSection = ({
   librariesV1Enabled,
   librariesV2Enabled,
   showNewProgramContainer,
+  canAccessPrograms,
+  isProgramAccessLoading,
 }) => {
   const intl = useIntl();
   const navigate = useNavigate();
@@ -68,6 +70,12 @@ const TabsSection = ({
     setTabKey(initTabKeyState(pathname));
   }, [pathname]);
 
+  useEffect(() => {
+    if (!isProgramAccessLoading && !canAccessPrograms && pathname.includes('/programs')) {
+      navigate('/home', { replace: true });
+    }
+  }, [canAccessPrograms, isProgramAccessLoading, navigate, pathname]);
+
   const { courses, numPages, coursesCount } = useSelector(getStudioHomeData);
   const {
     courseLoadingStatus,
@@ -79,15 +87,17 @@ const TabsSection = ({
   // the correct operation of iterating over child elements inside the Paragon Tabs component.
   const visibleTabs = useMemo(() => {
     const tabs: JSX.Element[] = [];
-    tabs.push(
-      <Tab
-        key={TABS_LIST.programs}
-        eventKey={TABS_LIST.programs}
-        title={intl.formatMessage(messages.programsTabTitle)}
-      >
-        <ProgramsTab showNewProgramContainer={showNewProgramContainer} />
-      </Tab>,
-    );
+    if (canAccessPrograms) {
+      tabs.push(
+        <Tab
+          key={TABS_LIST.programs}
+          eventKey={TABS_LIST.programs}
+          title={intl.formatMessage(messages.programsTabTitle)}
+        >
+          <ProgramsTab showNewProgramContainer={showNewProgramContainer} />
+        </Tab>,
+      );
+    }
 
     tabs.push(
       <Tab
@@ -158,7 +168,13 @@ const TabsSection = ({
     }
 
     return tabs;
-  }, [showNewCourseContainer, showNewProgramContainer, isLoadingCourses, migrationFilter]);
+  }, [
+    canAccessPrograms,
+    showNewCourseContainer,
+    showNewProgramContainer,
+    isLoadingCourses,
+    migrationFilter,
+  ]);
 
   const handleSelectTab = (tab: TabKeyType) => {
     if (tab === TABS_LIST.courses) {
@@ -194,6 +210,8 @@ TabsSection.propTypes = {
   librariesV1Enabled: PropTypes.bool,
   librariesV2Enabled: PropTypes.bool,
   showNewProgramContainer: PropTypes.bool,
+  canAccessPrograms: PropTypes.bool.isRequired,
+  isProgramAccessLoading: PropTypes.bool.isRequired,
 };
 
 export default TabsSection;

--- a/src/studio-home/tabs-section/programs-tab/index.tsx
+++ b/src/studio-home/tabs-section/programs-tab/index.tsx
@@ -8,7 +8,7 @@ import {
 import { Check } from '@openedx/paragon/icons';
 import { useIntl, defineMessages } from '@edx/frontend-platform/i18n';
 import { LoadingSpinner } from '@src/generic/Loading';
-import { usePrograms } from '../../../programs/data/apiHooks';
+import { useProgramAccess, usePrograms } from '../../../programs/data/apiHooks';
 import ProgramCard from './ProgramCard';
 
 const messages = defineMessages({
@@ -28,6 +28,10 @@ const messages = defineMessages({
     id: 'course-authoring.studio-home.programs.tab.empty',
     defaultMessage: 'No programs yet. Click "New program" to create one.',
   },
+  emptyReadOnlyState: {
+    id: 'course-authoring.studio-home.programs.tab.empty.read-only',
+    defaultMessage: 'No programs are available to you.',
+  },
   emptySearch: {
     id: 'course-authoring.studio-home.programs.tab.empty-search',
     defaultMessage: 'No programs match your search.',
@@ -40,6 +44,7 @@ const ProgramsTab: React.FC<{ showNewProgramContainer?: boolean }> = () => {
   const intl = useIntl();
   const [search, setSearch] = useState('');
   const [sortOrder, setSortOrder] = useState<SortOrder>('az');
+  const { capabilities } = useProgramAccess();
 
   // Treat API errors the same as empty — don't show a jarring error banner for the list
   const { data: programs = [], isLoading } = usePrograms();
@@ -118,7 +123,9 @@ const ProgramsTab: React.FC<{ showNewProgramContainer?: boolean }> = () => {
         <p className="text-muted">
           {search.trim()
             ? intl.formatMessage(messages.emptySearch)
-            : intl.formatMessage(messages.emptyState)}
+            : intl.formatMessage(
+              capabilities.canCreateProgram ? messages.emptyState : messages.emptyReadOnlyState,
+            )}
         </p>
       ) : (
         filteredPrograms.map((program) => (


### PR DESCRIPTION
- Added `useProgramAccess` hook to manage user permissions based on roles.
- Updated `ProgramDetailPage` to conditionally render UI elements based on user capabilities.
- Introduced read-only modes for various tabs (Courses, Enrollment, Instructors) based on user permissions.
- Enhanced tests to cover new permission logic and UI behavior for different user roles.
- Added new API endpoints for fetching user profiles and cities for program creation.