### PR TITLE
feat: wire programs permissions, team endpoint, and learner type filter

### DIFF
--- a/src/programs/ProgramDetailPage.tsx
+++ b/src/programs/ProgramDetailPage.tsx
@@ -55,6 +55,7 @@ const messages = defineMessages({
   fieldShortDescHint: { id: 'programs.detail.field.short-desc.hint', defaultMessage: 'Appears in program listings and cards. Keep it concise.' },
   fieldDetailedDesc: { id: 'programs.detail.field.long-desc', defaultMessage: 'Detailed Description' },
   fieldDetailedDescHint: { id: 'programs.detail.field.long-desc.hint', defaultMessage: 'Appears on the program detail page. Provide comprehensive information.' },
+  fieldCity: { id: 'programs.detail.field.city', defaultMessage: 'City' },
   fieldAudience: { id: 'programs.detail.field.audience', defaultMessage: 'Target Audience' },
   fieldAudienceHint: { id: 'programs.detail.field.audience.hint', defaultMessage: 'Choose an existing type or type a new one to create it.' },
   fieldAudiencePlaceholder: { id: 'programs.detail.field.audience.placeholder', defaultMessage: 'Select or add audience type...' },
@@ -142,6 +143,7 @@ const ProgramDetailPage: React.FC = () => {
 
   const { data, isLoading, isError } = useProgramDetail(programId ?? '');
   const { mutateAsync: updateProgram, isPending: isSaving } = useUpdateProgram();
+  const cities = data?.availableCities ?? [];
 
   const program = data?.program;
   const availableAudiences = data?.availableAudiences ?? [];
@@ -151,6 +153,7 @@ const ProgramDetailPage: React.FC = () => {
     initialValues: {
       displayName: program?.displayName ?? '',
       targetAudience: program?.targetAudience ?? '',
+      city: program?.city ?? '',
       shortDescription: program?.shortDescription ?? '',
       longDescription: program?.longDescription ?? '',
       status: program?.status ?? 'draft',
@@ -381,6 +384,22 @@ const ProgramDetailPage: React.FC = () => {
                           }}
                         />
                         <Form.Text muted>{intl.formatMessage(messages.fieldAudienceHint)}</Form.Text>
+                      </Form.Group>
+
+                      {/* City */}
+                      <Form.Group className="mb-4">
+                        <Form.Label>{intl.formatMessage(messages.fieldCity)}</Form.Label>
+                        <Form.Control
+                          as="select"
+                          name="city"
+                          value={formik.values.city ?? ''}
+                          onChange={formik.handleChange}
+                        >
+                          <option value="">— Select city —</option>
+                          {cities.map((c) => (
+                            <option key={c.id} value={c.name}>{c.name}</option>
+                          ))}
+                        </Form.Control>
                       </Form.Group>
 
                       {/* Start / End Dates */}

--- a/src/programs/data/api.ts
+++ b/src/programs/data/api.ts
@@ -38,6 +38,7 @@ const toProgram = (d: any): Program => ({
   programType: d.program_type,
   run: d.batch,
   targetAudience: d.target_audience?.name ?? '',
+  city: d.city?.name ?? '',
   shortDescription: d.description ?? '',
   longDescription: d.long_description ?? '',
   status: d.status ?? 'draft',
@@ -54,6 +55,7 @@ export const getProgramsConfig = async (): Promise<ProgramConfig> => {
   return {
     orgs: data.organizations.map((o: any) => ({ id: o.id, name: o.name, shortName: o.short_name })),
     programTypes: data.program_types.map((t: any) => ({ id: t.id, name: t.name, slug: t.slug })),
+    cities: (data.cities ?? []).map((c: any) => ({ id: c.id, name: c.name })),
     // Statuses are stable constants; not returned by config endpoint
     statuses: ['draft', 'active', 'archived', 'freezed'],
   };
@@ -74,6 +76,8 @@ export const getProgramDetail = async (programId: string): Promise<ProgramDetail
     program: toProgram(data),
     // target_audiences in the detail response is the full list of all audiences system-wide
     availableAudiences: (data.target_audiences ?? []).map((a: any) => a.name as string),
+    // cities in the detail response is the full list of all cities
+    availableCities: (data.cities ?? []).map((c: any) => ({ id: c.id, name: c.name })),
   };
 };
 
@@ -84,6 +88,7 @@ export const createProgram = async (input: Omit<Program, 'id'>): Promise<Program
     organization: input.org,
     program_type: input.programType,
     batch: input.run,
+    ...(input.city ? { city: input.city } : {}),
   };
   const { data } = await getAuthenticatedHttpClient().post(`${getProgramsBaseUrl()}/`, payload);
   return toProgram(data);
@@ -107,6 +112,7 @@ export const updateProgram = async (
   if (data.startDate !== undefined) { formData.append('start_date', data.startDate ?? ''); }
   if (data.endDate !== undefined) { formData.append('end_date', data.endDate ?? ''); }
   if (data.targetAudience !== undefined) { formData.append('target_audience', data.targetAudience ?? ''); }
+  if (data.city !== undefined) { formData.append('city', data.city ?? ''); }
   if (imageFile) { formData.append('card_image', imageFile); }
 
   // Intentionally not sent: org / programType / run (immutable after creation)
@@ -179,6 +185,7 @@ export const updateCourseTargetAudience = async (
 export interface GetInstructorsParams {
   page?: number;
   search?: string;
+  programKey?: string;
 }
 
 export interface GetLearnersParams {
@@ -209,7 +216,7 @@ export const getPlatformUsers = async (
         page: params.page ?? 1,
         page_size: pageSize,
         ...(params.search ? { search: params.search } : {}),
-        ...(params.role === 'learner' && params.programKey ? { program_key: params.programKey } : {}),
+        ...(params.programKey ? { program_key: params.programKey } : {}),
       },
     },
   );

--- a/src/programs/data/api.ts
+++ b/src/programs/data/api.ts
@@ -184,6 +184,7 @@ export interface GetInstructorsParams {
 export interface GetLearnersParams {
   page?: number;
   search?: string;
+  programKey?: string;
 }
 
 // Shared mapping from UserSerializer response ({id, username, email, first_name, last_name})
@@ -208,6 +209,7 @@ export const getPlatformUsers = async (
         page: params.page ?? 1,
         page_size: pageSize,
         ...(params.search ? { search: params.search } : {}),
+        ...(params.role === 'learner' && params.programKey ? { program_key: params.programKey } : {}),
       },
     },
   );
@@ -220,26 +222,26 @@ export const getPlatformUsers = async (
   };
 };
 
-// ── Course team — GET ${STUDIO_BASE_URL}/api/contentstore/v1/course_team/<id> ─
+// ── Course team — GET /fbr/api/programs/courses/<course_key>/team/ ─────────
 export const getCourseTeam = async (courseId: string): Promise<Instructor[]> => {
   const { data } = await getAuthenticatedHttpClient().get(
-    `${getConfig().STUDIO_BASE_URL}/api/contentstore/v1/course_team/${courseId}`,
+    `${getProgramsBaseUrl()}/courses/${encodeURIComponent(courseId)}/team/`,
   );
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (data.users ?? []).map((u: any) => ({
+  return (Array.isArray(data) ? data : (data.results ?? [])).map((u: any) => ({
     id: u.username,
     username: u.username,
     email: u.email,
     role: u.role,
-    name: u.username,
+    name: [u.first_name, u.last_name].filter(Boolean).join(' ') || u.username,
   }));
 };
 
-// ── Add instructor to course — POST ${STUDIO_BASE_URL}/course_team/<id>/<email>
-export const addInstructorToCourse = async (courseId: string, email: string): Promise<void> => {
+// ── Add instructor to course — POST /fbr/api/programs/courses/<course_key>/team/
+export const addInstructorToCourse = async (courseId: string, username: string): Promise<void> => {
   await getAuthenticatedHttpClient().post(
-    `${getConfig().STUDIO_BASE_URL}/course_team/${courseId}/${email}`,
-    { role: 'staff' },
+    `${getProgramsBaseUrl()}/courses/${encodeURIComponent(courseId)}/team/`,
+    { username },
   );
 };
 

--- a/src/programs/data/apiHooks.ts
+++ b/src/programs/data/apiHooks.ts
@@ -119,7 +119,7 @@ export const useUpdateCourseTargetAudience = () => {
 };
 
 export const useInstructors = (params: GetInstructorsParams = {}, enabled = true) => useQuery({
-  queryKey: ['instructors', params.page ?? 1, params.search ?? ''],
+  queryKey: ['instructors', params.programKey ?? '', params.page ?? 1, params.search ?? ''],
   queryFn: () => getPlatformUsers({ role: 'instructor', ...params }),
   placeholderData: keepPreviousData,
   staleTime: 0,

--- a/src/programs/data/apiHooks.ts
+++ b/src/programs/data/apiHooks.ts
@@ -36,6 +36,8 @@ export const useProgramsConfig = () => useQuery({
 export const usePrograms = () => useQuery({
   queryKey: ['programs'],
   queryFn: getPrograms,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  retry: (failureCount, error: any) => error?.response?.status !== 403 && failureCount < 3,
 });
 
 export const useProgramDetail = (programId: string) => useQuery({
@@ -127,8 +129,8 @@ export const useInstructors = (params: GetInstructorsParams = {}, enabled = true
 export const useAddInstructorToCourse = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ courseId, email }: { courseId: string; email: string }) => (
-      addInstructorToCourse(courseId, email)
+    mutationFn: ({ courseId, username }: { courseId: string; username: string }) => (
+      addInstructorToCourse(courseId, username)
     ),
     onSuccess: (_, { courseId }) => {
       queryClient.invalidateQueries({ queryKey: ['courseTeam', courseId] });
@@ -149,7 +151,7 @@ export const useRemoveInstructorFromCourse = () => {
 };
 
 export const useLearners = (params: GetLearnersParams = {}, enabled = true) => useQuery({
-  queryKey: ['learners', params.page ?? 1, params.search ?? ''],
+  queryKey: ['learners', params.programKey ?? '', params.page ?? 1, params.search ?? ''],
   queryFn: () => getPlatformUsers({ role: 'learner', ...params }),
   placeholderData: keepPreviousData,
   staleTime: 0,

--- a/src/programs/data/types.ts
+++ b/src/programs/data/types.ts
@@ -19,6 +19,7 @@ export interface Program {
   programType: string;
   run: string;
   targetAudience: string;
+  city?: string;
   shortDescription?: string;
   longDescription?: string;
   status?: string;
@@ -35,6 +36,11 @@ export interface OrgOption {
   shortName: string;
 }
 
+export interface CityOption {
+  id: number;
+  name: string;
+}
+
 export interface ProgramTypeOption {
   id: number;
   name: string;
@@ -45,12 +51,15 @@ export interface ProgramConfig {
   orgs: OrgOption[];
   programTypes: ProgramTypeOption[];
   statuses: string[];
+  cities: CityOption[];
 }
 
 export interface ProgramDetailResponse {
   program: Program;
   /** All target audiences available system-wide — used for the dropdown options. */
   availableAudiences: string[];
+  /** All cities available — returned by the detail endpoint alongside the program. */
+  availableCities: CityOption[];
 }
 
 export interface Instructor {

--- a/src/programs/enrollment-tab/AddLearnerModal.tsx
+++ b/src/programs/enrollment-tab/AddLearnerModal.tsx
@@ -42,10 +42,13 @@ const AddLearnerModal: React.FC<AddLearnerModalProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [enrollingId, setEnrollingId] = useState<string | null>(null);
-  const [enrollError, setEnrollError] = useState(false);
+  const [enrollError, setEnrollError] = useState<string | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
-  const { data, isLoading, isFetching } = useLearners({ page: currentPage, search: searchQuery }, isOpen);
+  const { data, isLoading, isFetching } = useLearners(
+    { page: currentPage, search: searchQuery, programKey: programId },
+    isOpen,
+  );
   const { mutateAsync: enrollLearner } = useEnrollLearner();
 
   useEffect(() => {
@@ -59,11 +62,13 @@ const AddLearnerModal: React.FC<AddLearnerModalProps> = ({
 
   const handleEnroll = async (username: string) => {
     setEnrollingId(username);
-    setEnrollError(false);
+    setEnrollError(null);
     try {
       await enrollLearner({ programId, username });
-    } catch {
-      setEnrollError(true);
+    } catch (err: any) {
+      setEnrollError(
+        err?.response?.data?.detail ?? intl.formatMessage(messages.enrollError),
+      );
     } finally {
       setEnrollingId(null);
     }
@@ -72,7 +77,7 @@ const AddLearnerModal: React.FC<AddLearnerModalProps> = ({
   const handleClose = () => {
     setSearchQuery('');
     setCurrentPage(1);
-    setEnrollError(false);
+    setEnrollError(null);
     onClose();
   };
 
@@ -100,9 +105,7 @@ const AddLearnerModal: React.FC<AddLearnerModalProps> = ({
 
       <ModalDialog.Body>
         {enrollError && (
-          <Alert variant="danger" className="mb-3">
-            {intl.formatMessage(messages.enrollError)}
-          </Alert>
+          <Alert variant="danger" className="mb-3">{enrollError}</Alert>
         )}
         {isLoading && (
           <div className="d-flex justify-content-center py-4">

--- a/src/programs/instructors-tab/AddInstructorModal.test.tsx
+++ b/src/programs/instructors-tab/AddInstructorModal.test.tsx
@@ -28,6 +28,7 @@ const defaultProps = {
   courseId: 'course-v1:Org+X+2025',
   courseName: 'CS 101',
   alreadyAddedUsernames: [],
+  programId: 'program-v1:Org+DST_IST+2025-B',
 };
 
 describe('<AddInstructorModal />', () => {
@@ -97,7 +98,7 @@ describe('<AddInstructorModal />', () => {
   it('passes enabled=false to useInstructors when modal is closed', () => {
     render(<AddInstructorModal {...defaultProps} isOpen={false} />);
     expect(mockUseInstructors).toHaveBeenCalledWith(
-      expect.any(Object),
+      expect.objectContaining({ programKey: 'program-v1:Org+DST_IST+2025-B' }),
       false,
     );
   });

--- a/src/programs/instructors-tab/AddInstructorModal.test.tsx
+++ b/src/programs/instructors-tab/AddInstructorModal.test.tsx
@@ -27,7 +27,7 @@ const defaultProps = {
   onClose: jest.fn(),
   courseId: 'course-v1:Org+X+2025',
   courseName: 'CS 101',
-  alreadyAddedEmails: [],
+  alreadyAddedUsernames: [],
 };
 
 describe('<AddInstructorModal />', () => {
@@ -53,7 +53,7 @@ describe('<AddInstructorModal />', () => {
       isLoading: false,
       isFetching: false,
     });
-    render(<AddInstructorModal {...defaultProps} alreadyAddedEmails={['john@example.com']} />);
+    render(<AddInstructorModal {...defaultProps} alreadyAddedUsernames={['prof.john']} />);
     expect(screen.getByText('Added')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^Add$/i })).not.toBeInTheDocument();
   });
@@ -73,7 +73,7 @@ describe('<AddInstructorModal />', () => {
     fireEvent.click(screen.getByRole('button', { name: /^Add$/i }));
     await waitFor(() => expect(mockAddMutate).toHaveBeenCalledWith({
       courseId: 'course-v1:Org+X+2025',
-      email: 'jane@example.com',
+      username: 'prof.john',
     }));
   });
 

--- a/src/programs/instructors-tab/AddInstructorModal.tsx
+++ b/src/programs/instructors-tab/AddInstructorModal.tsx
@@ -33,10 +33,11 @@ interface AddInstructorModalProps {
   courseId: string;
   courseName: string;
   alreadyAddedUsernames: string[];
+  programId: string;
 }
 
 const AddInstructorModal: React.FC<AddInstructorModalProps> = ({
-  isOpen, onClose, courseId, courseName, alreadyAddedUsernames,
+  isOpen, onClose, courseId, courseName, alreadyAddedUsernames, programId,
 }) => {
   const intl = useIntl();
   const [searchQuery, setSearchQuery] = useState('');
@@ -46,7 +47,7 @@ const AddInstructorModal: React.FC<AddInstructorModalProps> = ({
   const listRef = useRef<HTMLDivElement>(null);
 
   const { data, isLoading, isFetching } = useInstructors(
-    { page: currentPage, search: searchQuery },
+    { page: currentPage, search: searchQuery, programKey: programId },
     isOpen,
   );
   const { mutateAsync: addInstructor } = useAddInstructorToCourse();

--- a/src/programs/instructors-tab/AddInstructorModal.tsx
+++ b/src/programs/instructors-tab/AddInstructorModal.tsx
@@ -32,17 +32,17 @@ interface AddInstructorModalProps {
   onClose: () => void;
   courseId: string;
   courseName: string;
-  alreadyAddedEmails: string[];
+  alreadyAddedUsernames: string[];
 }
 
 const AddInstructorModal: React.FC<AddInstructorModalProps> = ({
-  isOpen, onClose, courseId, courseName, alreadyAddedEmails,
+  isOpen, onClose, courseId, courseName, alreadyAddedUsernames,
 }) => {
   const intl = useIntl();
   const [searchQuery, setSearchQuery] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [addingId, setAddingId] = useState<string | null>(null);
-  const [addError, setAddError] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
   const { data, isLoading, isFetching } = useInstructors(
@@ -60,13 +60,15 @@ const AddInstructorModal: React.FC<AddInstructorModalProps> = ({
     setCurrentPage(1);
   }, []);
 
-  const handleAdd = async (email: string) => {
-    setAddingId(email);
-    setAddError(false);
+  const handleAdd = async (username: string) => {
+    setAddingId(username);
+    setAddError(null);
     try {
-      await addInstructor({ courseId, email });
-    } catch {
-      setAddError(true);
+      await addInstructor({ courseId, username });
+    } catch (err: any) {
+      setAddError(
+        err?.response?.data?.detail ?? intl.formatMessage(messages.addError),
+      );
     } finally {
       setAddingId(null);
     }
@@ -75,7 +77,7 @@ const AddInstructorModal: React.FC<AddInstructorModalProps> = ({
   const handleClose = () => {
     setSearchQuery('');
     setCurrentPage(1);
-    setAddError(false);
+    setAddError(null);
     onClose();
   };
 
@@ -103,9 +105,7 @@ const AddInstructorModal: React.FC<AddInstructorModalProps> = ({
 
       <ModalDialog.Body>
         {addError && (
-          <Alert variant="danger" className="mb-3">
-            {intl.formatMessage(messages.addError)}
-          </Alert>
+          <Alert variant="danger" className="mb-3">{addError}</Alert>
         )}
         {isLoading && (
           <div className="d-flex justify-content-center py-4">
@@ -118,8 +118,8 @@ const AddInstructorModal: React.FC<AddInstructorModalProps> = ({
         <div ref={listRef} />
         <div style={{ opacity: isFetching && !isLoading ? 0.4 : 1, transition: 'opacity 0.15s' }}>
           {!isLoading && data?.results.map((instructor) => {
-            const isAdded = alreadyAddedEmails.includes(instructor.email);
-            const isAdding = addingId === instructor.email;
+            const isAdded = alreadyAddedUsernames.includes(instructor.username);
+            const isAdding = addingId === instructor.username;
             return (
               <div
                 key={instructor.id}
@@ -136,7 +136,7 @@ const AddInstructorModal: React.FC<AddInstructorModalProps> = ({
                   <Button
                     variant="primary"
                     size="sm"
-                    onClick={() => handleAdd(instructor.email)}
+                    onClick={() => handleAdd(instructor.username)}
                     disabled={isAdding || !!addingId}
                   >
                     {isAdding ? intl.formatMessage(messages.addingBtn) : intl.formatMessage(messages.addBtn)}

--- a/src/programs/instructors-tab/InstructorsTab.tsx
+++ b/src/programs/instructors-tab/InstructorsTab.tsx
@@ -157,6 +157,7 @@ const InstructorsTab: React.FC<InstructorsTabProps> = ({ program }) => {
         courseId={selectedCourseId}
         courseName={selectedCourse?.displayName ?? ''}
         alreadyAddedUsernames={teamUsernames}
+        programId={program.id}
       />
 
       <DeleteModal

--- a/src/programs/instructors-tab/InstructorsTab.tsx
+++ b/src/programs/instructors-tab/InstructorsTab.tsx
@@ -46,7 +46,7 @@ const InstructorsTab: React.FC<InstructorsTabProps> = ({ program }) => {
   const { data: team, isLoading: isTeamLoading } = useCourseTeam(selectedCourseId, !!selectedCourseId);
   const removeInstructor = useRemoveInstructorFromCourse();
 
-  const teamEmails = team?.map((i) => i.email) ?? [];
+  const teamUsernames = team?.map((i) => i.username) ?? [];
   const selectedCourse = courses.find((c) => c.id === selectedCourseId);
 
   const handleCourseChange = useCallback((courseId: string) => {
@@ -156,7 +156,7 @@ const InstructorsTab: React.FC<InstructorsTabProps> = ({ program }) => {
         onClose={closeModal}
         courseId={selectedCourseId}
         courseName={selectedCourse?.displayName ?? ''}
-        alreadyAddedEmails={teamEmails}
+        alreadyAddedUsernames={teamUsernames}
       />
 
       <DeleteModal

--- a/src/studio-home/StudioHome.tsx
+++ b/src/studio-home/StudioHome.tsx
@@ -25,11 +25,16 @@ import CreateNewProgramForm from './create-new-program-form';
 import messages from './messages';
 import { useStudioHome } from './hooks';
 import AlertMessage from '../generic/alert-message';
+import { usePrograms } from '../programs/data/apiHooks';
 
 const StudioHome = () => {
   const intl = useIntl();
   const location = useLocation();
   const navigate = useNavigate();
+
+  const { error: programsError } = usePrograms();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const isProgramAdmin = (programsError as any)?.response?.status !== 403;
 
   const {
     isLoadingPage,
@@ -74,17 +79,19 @@ const StudioHome = () => {
       );
     }
 
-    headerButtons.push(
-      <Button
-        variant="outline-primary"
-        iconBefore={AddIcon}
-        size="sm"
-        disabled={showNewProgramContainer}
-        onClick={() => setShowNewProgramContainer(true)}
-      >
-        {intl.formatMessage(messages.addNewProgramBtnText)}
-      </Button>,
-    );
+    if (isProgramAdmin) {
+      headerButtons.push(
+        <Button
+          variant="outline-primary"
+          iconBefore={AddIcon}
+          size="sm"
+          disabled={showNewProgramContainer}
+          onClick={() => setShowNewProgramContainer(true)}
+        >
+          {intl.formatMessage(messages.addNewProgramBtnText)}
+        </Button>,
+      );
+    }
 
     if (hasAbilityToCreateNewCourse) {
       headerButtons.push(
@@ -122,7 +129,7 @@ const StudioHome = () => {
     }
 
     return headerButtons;
-  }, [location, userIsActive, isFailedLoadingPage]);
+  }, [location, userIsActive, isFailedLoadingPage, isProgramAdmin, showNewProgramContainer]);
 
   const headerButtons = userIsActive ? getHeaderButtons() : [];
   if (isLoadingPage && !isFiltered) {

--- a/src/studio-home/StudioHome.tsx
+++ b/src/studio-home/StudioHome.tsx
@@ -25,16 +25,11 @@ import CreateNewProgramForm from './create-new-program-form';
 import messages from './messages';
 import { useStudioHome } from './hooks';
 import AlertMessage from '../generic/alert-message';
-import { usePrograms } from '../programs/data/apiHooks';
 
 const StudioHome = () => {
   const intl = useIntl();
   const location = useLocation();
   const navigate = useNavigate();
-
-  const { error: programsError } = usePrograms();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const isProgramAdmin = (programsError as any)?.response?.status !== 403;
 
   const {
     isLoadingPage,
@@ -79,7 +74,7 @@ const StudioHome = () => {
       );
     }
 
-    if (isProgramAdmin) {
+    if (hasAbilityToCreateNewCourse) {
       headerButtons.push(
         <Button
           variant="outline-primary"
@@ -129,7 +124,7 @@ const StudioHome = () => {
     }
 
     return headerButtons;
-  }, [location, userIsActive, isFailedLoadingPage, isProgramAdmin, showNewProgramContainer]);
+  }, [location, userIsActive, isFailedLoadingPage, hasAbilityToCreateNewCourse, showNewProgramContainer]);
 
   const headerButtons = userIsActive ? getHeaderButtons() : [];
   if (isLoadingPage && !isFiltered) {

--- a/src/studio-home/create-new-program-form/index.jsx
+++ b/src/studio-home/create-new-program-form/index.jsx
@@ -21,6 +21,7 @@ const CreateNewProgramForm = ({ handleOnClickCancel }) => {
 
   const orgs = config?.orgs ?? [];
   const programTypes = config?.programTypes ?? [];
+  const cities = config?.cities ?? [];
 
   const validationSchema = Yup.object({
     displayName: Yup.string().trim().required(intl.formatMessage(messages.programNameRequired)),
@@ -56,6 +57,7 @@ const CreateNewProgramForm = ({ handleOnClickCancel }) => {
           org: '',
           programType: '',
           run: '',
+          city: '',
         }}
         validationSchema={validationSchema}
         onSubmit={handleSubmit}
@@ -147,6 +149,21 @@ const CreateNewProgramForm = ({ handleOnClickCancel }) => {
               {touched.run && errors.run && (
                 <Form.Control.Feedback type="invalid">{errors.run}</Form.Control.Feedback>
               )}
+            </Form.Group>
+
+            {/* City */}
+            <Form.Group>
+              <Form.Label>{intl.formatMessage(messages.cityLabel)}</Form.Label>
+              <Form.Control
+                as="select"
+                name="city"
+                value={values.city}
+                onChange={handleChange}
+                onBlur={handleBlur}
+              >
+                <option value="">{intl.formatMessage(messages.selectPlaceholder)}</option>
+                {cities.map((c) => <option key={c.id} value={c.name}>{c.name}</option>)}
+              </Form.Control>
             </Form.Group>
 
             <div className="d-flex justify-content-end gap-2 mt-3">

--- a/src/studio-home/create-new-program-form/messages.js
+++ b/src/studio-home/create-new-program-form/messages.js
@@ -65,6 +65,10 @@ const messages = defineMessages({
     id: 'course-authoring.studio-home.new-program.pending.btn',
     defaultMessage: 'Creating...',
   },
+  cityLabel: {
+    id: 'course-authoring.studio-home.new-program.city.label',
+    defaultMessage: 'City',
+  },
   selectPlaceholder: {
     id: 'course-authoring.studio-home.new-program.select.placeholder',
     defaultMessage: 'Select...',

--- a/src/studio-home/tabs-section/index.tsx
+++ b/src/studio-home/tabs-section/index.tsx
@@ -12,6 +12,7 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import { useNavigate, useLocation } from 'react-router-dom';
 
 import { RequestStatus } from '@src/data/constants';
+import { COURSE_CREATOR_STATES } from '@src/constants';
 import { getLoadingStatuses, getStudioHomeData } from '../data/selectors';
 import messages from './messages';
 import { BaseFilterState, Filter, LibrariesList } from './libraries-tab';
@@ -19,7 +20,6 @@ import LibrariesV2List from './libraries-v2-tab/index';
 import CoursesTab from './courses-tab';
 import ProgramsTab from './programs-tab';
 import { WelcomeLibrariesV2Alert } from './libraries-v2-tab/WelcomeLibrariesV2Alert';
-import { usePrograms } from '../../programs/data/apiHooks';
 
 const TabsSection = ({
   showNewCourseContainer,
@@ -69,11 +69,8 @@ const TabsSection = ({
     setTabKey(initTabKeyState(pathname));
   }, [pathname]);
 
-  const { error: programsError } = usePrograms();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const isProgramAdmin = (programsError as any)?.response?.status !== 403;
-
-  const { courses, numPages, coursesCount } = useSelector(getStudioHomeData);
+  const { courses, numPages, coursesCount, courseCreatorStatus } = useSelector(getStudioHomeData);
+  const isProgramAdmin = courseCreatorStatus === COURSE_CREATOR_STATES.granted;
   const {
     courseLoadingStatus,
   } = useSelector(getLoadingStatuses);

--- a/src/studio-home/tabs-section/index.tsx
+++ b/src/studio-home/tabs-section/index.tsx
@@ -19,6 +19,7 @@ import LibrariesV2List from './libraries-v2-tab/index';
 import CoursesTab from './courses-tab';
 import ProgramsTab from './programs-tab';
 import { WelcomeLibrariesV2Alert } from './libraries-v2-tab/WelcomeLibrariesV2Alert';
+import { usePrograms } from '../../programs/data/apiHooks';
 
 const TabsSection = ({
   showNewCourseContainer,
@@ -68,6 +69,10 @@ const TabsSection = ({
     setTabKey(initTabKeyState(pathname));
   }, [pathname]);
 
+  const { error: programsError } = usePrograms();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const isProgramAdmin = (programsError as any)?.response?.status !== 403;
+
   const { courses, numPages, coursesCount } = useSelector(getStudioHomeData);
   const {
     courseLoadingStatus,
@@ -79,15 +84,17 @@ const TabsSection = ({
   // the correct operation of iterating over child elements inside the Paragon Tabs component.
   const visibleTabs = useMemo(() => {
     const tabs: JSX.Element[] = [];
-    tabs.push(
-      <Tab
-        key={TABS_LIST.programs}
-        eventKey={TABS_LIST.programs}
-        title={intl.formatMessage(messages.programsTabTitle)}
-      >
-        <ProgramsTab showNewProgramContainer={showNewProgramContainer} />
-      </Tab>,
-    );
+    if (isProgramAdmin) {
+      tabs.push(
+        <Tab
+          key={TABS_LIST.programs}
+          eventKey={TABS_LIST.programs}
+          title={intl.formatMessage(messages.programsTabTitle)}
+        >
+          <ProgramsTab showNewProgramContainer={showNewProgramContainer} />
+        </Tab>,
+      );
+    }
 
     tabs.push(
       <Tab
@@ -158,7 +165,7 @@ const TabsSection = ({
     }
 
     return tabs;
-  }, [showNewCourseContainer, showNewProgramContainer, isLoadingCourses, migrationFilter]);
+  }, [showNewCourseContainer, showNewProgramContainer, isLoadingCourses, migrationFilter, isProgramAdmin]);
 
   const handleSelectTab = (tab: TabKeyType) => {
     if (tab === TABS_LIST.courses) {


### PR DESCRIPTION
## Summary                                                                                                                                                                
                                      
  - **Learner picker scoped by program type** — `GET /fbr/api/programs/users/?role=learner` now includes `program_key` so the backend returns only trainees whose           
  `trainee_type` matches the program's type.
  - **Instructor picker scoped by program** — `GET /fbr/api/programs/users/?role=instructor` also sends `program_key` so the backend can filter eligible instructors per    
  program.                                                                                                                                                                  
  - **Enrollment 400 handled** — if the backend rejects an enroll with a 400 (e.g. trainee type mismatch), the exact backend message is shown in the modal instead of a
  generic error.                                                                                                                                                            
  - **Programs gated for non-admins** — Programs tab and "New Program" button are hidden when `courseCreatorStatus !== 'granted'` (same mechanism as the New Course button).
   `usePrograms` does not retry on 403 to avoid request storms.                                                                                                             
  - **Course team endpoint switched** — `getCourseTeam` and `addInstructorToCourse` now call `GET/POST /fbr/api/programs/courses/<course_key>/team/`. Add instructor uses
  `{username}` in the request body; 400 responses surface the backend message.                                                                                              
  - **City field** — city dropdown added to both the Create New Program form (options from config API) and the Program Detail page (selected city and all options come from
  the program detail response — no extra API call).                                                                                                                         
                                                         
  ## Files changed                                                                                                                                                          
                                                         
  | File | Change |
  |------|--------|
  | `programs/data/types.ts` | `CityOption` type; `city` on `Program`; `cities` on `ProgramConfig`; `availableCities` on `ProgramDetailResponse` |
  | `programs/data/api.ts` | `program_key` on both learner and instructor fetch; city mapped in `toProgram`, `createProgram`, `updateProgram`; `availableCities` extracted in `getProgramDetail`; team GET/POST switched to FBR endpoint |                                                                                                           
  | `programs/data/apiHooks.ts` | `usePrograms` retry guard; `useLearners` / `useInstructors` query keys include `programKey` |                                             
  | `enrollment-tab/AddLearnerModal.tsx` | Passes `programId` as `programKey`; error state shows backend message |                                                          
  | `instructors-tab/AddInstructorModal.tsx` | Accepts `programId` prop; passes `programKey` to `useInstructors`; uses `username` throughout; error state shows backend message |                                                                                                                                                                 
  | `instructors-tab/InstructorsTab.tsx` | Passes `programId` and `alreadyAddedUsernames` (was emails) |                                                                    
  | `programs/ProgramDetailPage.tsx` | City dropdown wired to `availableCities` from detail response |                                                                      
  | `studio-home/create-new-program-form/` | City dropdown wired to config `cities`; `city` included in create payload |                                                    
  | `studio-home/StudioHome.tsx` | New Program button gated by `hasAbilityToCreateNewCourse` |
  | `studio-home/tabs-section/index.tsx` | Programs tab gated by `courseCreatorStatus === 'granted'` |                                                                      
                                                         
  ## Test plan                                                                                                                                                              
                                                         
  - [ ] Log in as a program admin — Programs tab and New Program button visible                                                                                             
  - [ ] Log in as an instructor/trainee — Programs tab and New Program button hidden
  - [ ] Open Enroll Learner modal on an STP program — only STP trainees appear in the picker                                                                                
  - [ ] Try to enroll a DST/IST trainee into an STP program — modal shows the backend error message
  - [ ] Create a new program — city dropdown populated from config; selected city sent on submit                                                                            
  - [ ] Open a program detail page — city dropdown pre-populated with the program's city; changing and saving persists correctly
  - [ ] Open Add Instructor modal — instructor list filtered by program; adding an instructor succeeds                                                                      
  - [ ] Try to add a non-FBR-instructor user — modal shows backend 400 message
  - [ ] Course team loads from FBR endpoint (not contentstore)    