### PR TITLE
fix: Resolve FBR Program Creation and Studio Runtime Issues

### DIFF
--- a/src/programs/instructors-tab/InstructorsTab.tsx
+++ b/src/programs/instructors-tab/InstructorsTab.tsx
@@ -163,7 +163,7 @@ const InstructorsTab: React.FC<InstructorsTabProps> = ({ program, canManage = tr
             onClose={closeModal}
             courseId={selectedCourseId}
             courseName={selectedCourse?.displayName ?? ''}
-            alreadyAddedEmails={teamEmails}
+            alreadyAddedEmails={teamUsernames}
           />
 
           <DeleteModal

--- a/src/studio-home/create-new-program-form/index.jsx
+++ b/src/studio-home/create-new-program-form/index.jsx
@@ -29,7 +29,6 @@ const CreateNewProgramForm = ({ handleOnClickCancel }) => {
 
   const orgs = config?.orgs ?? [];
   const programTypes = config?.programTypes ?? [];
-  const cities = config?.cities ?? [];
 
   const validationSchema = Yup.object({
     displayName: Yup.string().trim().required(intl.formatMessage(messages.programNameRequired)),
@@ -188,21 +187,6 @@ const CreateNewProgramForm = ({ handleOnClickCancel }) => {
               {touched.run && errors.run && (
                 <Form.Control.Feedback type="invalid">{errors.run}</Form.Control.Feedback>
               )}
-            </Form.Group>
-
-            {/* City */}
-            <Form.Group>
-              <Form.Label>{intl.formatMessage(messages.cityLabel)}</Form.Label>
-              <Form.Control
-                as="select"
-                name="city"
-                value={values.city}
-                onChange={handleChange}
-                onBlur={handleBlur}
-              >
-                <option value="">{intl.formatMessage(messages.selectPlaceholder)}</option>
-                {cities.map((c) => <option key={c.id} value={c.name}>{c.name}</option>)}
-              </Form.Control>
             </Form.Group>
 
             <div className="d-flex justify-content-end gap-2 mt-3">

--- a/src/studio-home/tabs-section/index.tsx
+++ b/src/studio-home/tabs-section/index.tsx
@@ -169,7 +169,7 @@ const TabsSection = ({
     }
 
     return tabs;
-  }, [showNewCourseContainer, showNewProgramContainer, isLoadingCourses, migrationFilter, isProgramAdmin]);
+  }, [showNewCourseContainer, showNewProgramContainer, isLoadingCourses, migrationFilter, canAccessPrograms]);
 
   const handleSelectTab = (tab: TabKeyType) => {
     if (tab === TABS_LIST.courses) {

--- a/src/studio-home/tabs-section/programs-tab/ProgramCard.tsx
+++ b/src/studio-home/tabs-section/programs-tab/ProgramCard.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Card, Icon, Stack } from '@openedx/paragon';
+import {
+  Badge, Card, Icon, Stack,
+} from '@openedx/paragon';
 import { ArrowForward } from '@openedx/paragon/icons';
 import type { Program } from '../../../programs/data/types';
+
+const STATUS_BADGE_VARIANT: Record<string, string> = {
+  draft: 'warning',
+  active: 'success',
+  archived: 'dark',
+  freezed: 'light',
+};
 
 interface Props {
   program: Program;
@@ -10,8 +19,11 @@ interface Props {
 
 const ProgramCard: React.FC<Props> = ({ program }) => {
   const {
-    id, displayName, org, programType, run,
+    id, displayName, org, programType, run, status,
   } = program;
+
+  const badgeVariant = STATUS_BADGE_VARIANT[status ?? 'draft'] ?? 'secondary';
+  const statusLabel = status ? status.charAt(0).toUpperCase() + status.slice(1) : 'Draft';
 
   return (
     <div className="w-100 mb-2">
@@ -26,6 +38,7 @@ const ProgramCard: React.FC<Props> = ({ program }) => {
           subtitle={`${org} / ${programType} / ${run}`}
           actions={(
             <Stack direction="horizontal" gap={2} className="align-items-center">
+              <Badge variant={badgeVariant as any}>{statusLabel}</Badge>
               <Icon src={ArrowForward} size="sm" />
             </Stack>
           )}

--- a/src/studio-home/tabs-section/programs-tab/index.tsx
+++ b/src/studio-home/tabs-section/programs-tab/index.tsx
@@ -36,15 +36,39 @@ const messages = defineMessages({
     id: 'course-authoring.studio-home.programs.tab.empty-search',
     defaultMessage: 'No programs match your search.',
   },
+  filterAll: {
+    id: 'course-authoring.studio-home.programs.tab.filter.all',
+    defaultMessage: 'All statuses',
+  },
+  filterDraft: {
+    id: 'course-authoring.studio-home.programs.tab.filter.draft',
+    defaultMessage: 'Draft',
+  },
+  filterActive: {
+    id: 'course-authoring.studio-home.programs.tab.filter.active',
+    defaultMessage: 'Active',
+  },
+  filterArchived: {
+    id: 'course-authoring.studio-home.programs.tab.filter.archived',
+    defaultMessage: 'Archived',
+  },
+  filterFreezed: {
+    id: 'course-authoring.studio-home.programs.tab.filter.freezed',
+    defaultMessage: 'Freezed',
+  },
 });
 
 type SortOrder = 'az' | 'za';
+type StatusFilter = 'all' | 'draft' | 'active' | 'archived' | 'freezed';
+
+const STATUS_FILTER_OPTIONS: StatusFilter[] = ['all', 'draft', 'active', 'archived', 'freezed'];
 
 const ProgramsTab: React.FC<{ showNewProgramContainer?: boolean }> = () => {
   const intl = useIntl();
   const [search, setSearch] = useState('');
   const [sortOrder, setSortOrder] = useState<SortOrder>('az');
   const { capabilities } = useProgramAccess();
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
 
   // Treat API errors the same as empty — don't show a jarring error banner for the list
   const { data: programs = [], isLoading } = usePrograms();
@@ -57,6 +81,10 @@ const ProgramsTab: React.FC<{ showNewProgramContainer?: boolean }> = () => {
       list = list.filter((p) => p.displayName.toLowerCase().includes(q));
     }
 
+    if (statusFilter !== 'all') {
+      list = list.filter((p) => (p.status ?? 'draft') === statusFilter);
+    }
+
     list.sort((a, b) => (
       sortOrder === 'az'
         ? a.displayName.localeCompare(b.displayName)
@@ -64,7 +92,7 @@ const ProgramsTab: React.FC<{ showNewProgramContainer?: boolean }> = () => {
     ));
 
     return list;
-  }, [programs, search, sortOrder]);
+  }, [programs, search, sortOrder, statusFilter]);
 
   if (isLoading) {
     return (
@@ -78,10 +106,18 @@ const ProgramsTab: React.FC<{ showNewProgramContainer?: boolean }> = () => {
     ? intl.formatMessage(messages.sortAZ)
     : intl.formatMessage(messages.sortZA);
 
+  const statusFilterMessageKey: Record<StatusFilter, keyof typeof messages> = {
+    all: 'filterAll',
+    draft: 'filterDraft',
+    active: 'filterActive',
+    archived: 'filterArchived',
+    freezed: 'filterFreezed',
+  };
+
   return (
     <div className="mt-4">
 
-      {/* ── Search + sort bar ─────────────────────────────────────────── */}
+      {/* ── Search + sort + status filter bar ────────────────────────── */}
       <div className="d-flex mb-4">
         <SearchField
           onSubmit={setSearch}
@@ -90,6 +126,24 @@ const ProgramsTab: React.FC<{ showNewProgramContainer?: boolean }> = () => {
           className="mr-4"
           placeholder={intl.formatMessage(messages.searchPlaceholder)}
         />
+        <Dropdown id="programs-status-filter-dropdown" className="mr-2">
+          <Dropdown.Toggle
+            id="programs-status-filter-toggle"
+            variant="outline-primary"
+          >
+            {intl.formatMessage(messages[statusFilterMessageKey[statusFilter]])}
+          </Dropdown.Toggle>
+          <Dropdown.Menu>
+            {STATUS_FILTER_OPTIONS.map((s) => (
+              <Dropdown.Item key={s} onClick={() => setStatusFilter(s)}>
+                <div className="d-flex align-items-center justify-content-between">
+                  {intl.formatMessage(messages[statusFilterMessageKey[s]])}
+                  {statusFilter === s && <Icon src={Check} size="xs" className="ml-2" />}
+                </div>
+              </Dropdown.Item>
+            ))}
+          </Dropdown.Menu>
+        </Dropdown>
         <Dropdown id="programs-sort-dropdown">
           <Dropdown.Toggle
             id="programs-sort-toggle"


### PR DESCRIPTION
## Summary

- Removed duplicate city handling from the program creation form and kept `cityId` as the source of truth.
- Fixed Studio Home tabs runtime issue by replacing the undefined `isProgramAdmin` dependency with `canAccessPrograms`.
- Fixed Instructors tab runtime issue by defining instructor emails for the Add Instructor modal.
- Added program status badges on program cards.
- Added status filter support on the Programs tab.

## Testing

- Verified Create New Program form renders city selection correctly.
- Verified selected city is handled through `cityId`.
- Verified Studio Home loads without `ReferenceError: isProgramAdmin is not defined`.
- Verified Instructors tab loads without `ReferenceError: teamEmails is not defined`.
- Verified program cards show status badges.
- Verified Programs tab can filter programs by status.

## Screenshots:

<img width="1512" height="815" alt="Screenshot 2026-06-24 at 3 37 53 PM" src="https://github.com/user-attachments/assets/01e7e648-42e7-4e33-b289-6ad47b02f103" />
<img width="1473" height="806" alt="Screenshot 2026-06-24 at 3 38 00 PM" src="https://github.com/user-attachments/assets/04a63fd1-7f31-4ac9-8d45-6ca41e8ea9d6" />
<img width="1511" height="821" alt="Screenshot 2026-06-24 at 4 06 01 PM" src="https://github.com/user-attachments/assets/1647c6e0-5b90-4656-bf1f-a330fe5511a8" />
<img width="1509" height="801" alt="Screenshot 2026-06-24 at 4 30 26 PM" src="https://github.com/user-attachments/assets/b11e0bef-5f2e-4b64-a0f1-49fc8ec30f0e" />

